### PR TITLE
Drop tini

### DIFF
--- a/core/bionic/Dockerfile
+++ b/core/bionic/Dockerfile
@@ -7,42 +7,6 @@
 # To update this file please edit the relevant template and run the generation
 # task `rake generate:core`
 
-########## tini ##########################
-# prepare tini binary (used as default entrypoint)
-FROM ubuntu:bionic as tini
-LABEL org.opencontainers.image.authors="djbender"
-LABEL org.opencontainers.image.source=https://github.com/djbender/docker-base-images
-
-ENV TINI_VERSION=v0.19.0
-# Options added via tini README.md suggestion
-# https://github.com/krallin/tini#building-tini
-ENV CFLAGS="-DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37"
-
-RUN <<EOT
-#!/usr/bin/env bash
-set -exu
-apt-get update
-apt-get install --yes --no-install-recommends \
-  build-essential \
-  ca-certificates \
-  cmake \
-  curl \
-  golang \
-  make \
-  tar
-update-ca-certificates
-curl -L https://github.com/krallin/tini/archive/refs/tags/$TINI_VERSION.tar.gz -o tini-$TINI_VERSION.tar.gz
-tar -xf tini-$TINI_VERSION.tar.gz
-# Compile tini from source to ensure compatability with the m1 architectures
-cd tini-$(echo $TINI_VERSION | cut -c2-)
-cmake .
-make
-# Ensure tini runs
-./tini-static --version
-mv ./tini-static /tini
-EOT
-
-
 ########## core image ##########################
 FROM ubuntu:bionic as core
 LABEL com.opencontainers.image.authors="djbender"
@@ -74,14 +38,8 @@ EOT
 ENV LANG en_US.utf-8
 ENV LANGUAGE en_US:en
 
-# Install Tini for init use (reaps defunct processes and forwards signals)
-COPY --from=tini /tini /tini
-
 # Switch to the 'docker' user
 USER docker
-
-# always use tini
-ENTRYPOINT ["/tini", "--"]
 
 # keep backwards compatability with use cases that assume CMD is 'bash' since
 # specifying an ENTRYPOINT always clears the CMD that was inheritted by the FROM image

--- a/core/jammy/Dockerfile
+++ b/core/jammy/Dockerfile
@@ -7,42 +7,6 @@
 # To update this file please edit the relevant template and run the generation
 # task `rake generate:core`
 
-########## tini ##########################
-# prepare tini binary (used as default entrypoint)
-FROM ubuntu:jammy as tini
-LABEL org.opencontainers.image.authors="djbender"
-LABEL org.opencontainers.image.source=https://github.com/djbender/docker-base-images
-
-ENV TINI_VERSION=v0.19.0
-# Options added via tini README.md suggestion
-# https://github.com/krallin/tini#building-tini
-ENV CFLAGS="-DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37"
-
-RUN <<EOT
-#!/usr/bin/env bash
-set -exu
-apt-get update
-apt-get install --yes --no-install-recommends \
-  build-essential \
-  ca-certificates \
-  cmake \
-  curl \
-  golang \
-  make \
-  tar
-update-ca-certificates
-curl -L https://github.com/krallin/tini/archive/refs/tags/$TINI_VERSION.tar.gz -o tini-$TINI_VERSION.tar.gz
-tar -xf tini-$TINI_VERSION.tar.gz
-# Compile tini from source to ensure compatability with the m1 architectures
-cd tini-$(echo $TINI_VERSION | cut -c2-)
-cmake .
-make
-# Ensure tini runs
-./tini-static --version
-mv ./tini-static /tini
-EOT
-
-
 ########## core image ##########################
 FROM ubuntu:jammy as core
 LABEL com.opencontainers.image.authors="djbender"
@@ -74,14 +38,8 @@ EOT
 ENV LANG en_US.utf-8
 ENV LANGUAGE en_US:en
 
-# Install Tini for init use (reaps defunct processes and forwards signals)
-COPY --from=tini /tini /tini
-
 # Switch to the 'docker' user
 USER docker
-
-# always use tini
-ENTRYPOINT ["/tini", "--"]
 
 # keep backwards compatability with use cases that assume CMD is 'bash' since
 # specifying an ENTRYPOINT always clears the CMD that was inheritted by the FROM image

--- a/core/noble/Dockerfile
+++ b/core/noble/Dockerfile
@@ -7,42 +7,6 @@
 # To update this file please edit the relevant template and run the generation
 # task `rake generate:core`
 
-########## tini ##########################
-# prepare tini binary (used as default entrypoint)
-FROM ubuntu:noble as tini
-LABEL org.opencontainers.image.authors="djbender"
-LABEL org.opencontainers.image.source=https://github.com/djbender/docker-base-images
-
-ENV TINI_VERSION=v0.19.0
-# Options added via tini README.md suggestion
-# https://github.com/krallin/tini#building-tini
-ENV CFLAGS="-DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37"
-
-RUN <<EOT
-#!/usr/bin/env bash
-set -exu
-apt-get update
-apt-get install --yes --no-install-recommends \
-  build-essential \
-  ca-certificates \
-  cmake \
-  curl \
-  golang \
-  make \
-  tar
-update-ca-certificates
-curl -L https://github.com/krallin/tini/archive/refs/tags/$TINI_VERSION.tar.gz -o tini-$TINI_VERSION.tar.gz
-tar -xf tini-$TINI_VERSION.tar.gz
-# Compile tini from source to ensure compatability with the m1 architectures
-cd tini-$(echo $TINI_VERSION | cut -c2-)
-cmake .
-make
-# Ensure tini runs
-./tini-static --version
-mv ./tini-static /tini
-EOT
-
-
 ########## core image ##########################
 FROM ubuntu:noble as core
 LABEL com.opencontainers.image.authors="djbender"
@@ -75,14 +39,8 @@ EOT
 ENV LANG en_US.utf-8
 ENV LANGUAGE en_US:en
 
-# Install Tini for init use (reaps defunct processes and forwards signals)
-COPY --from=tini /tini /tini
-
 # Switch to the 'docker' user
 USER docker
-
-# always use tini
-ENTRYPOINT ["/tini", "--"]
 
 # keep backwards compatability with use cases that assume CMD is 'bash' since
 # specifying an ENTRYPOINT always clears the CMD that was inheritted by the FROM image

--- a/core/template/Dockerfile.erb
+++ b/core/template/Dockerfile.erb
@@ -2,42 +2,6 @@
 
 <%= generation_message -%>
 
-########## tini ##########################
-# prepare tini binary (used as default entrypoint)
-FROM ubuntu:<%= distribution_code_name %> as tini
-LABEL org.opencontainers.image.authors="djbender"
-LABEL org.opencontainers.image.source=https://github.com/djbender/docker-base-images
-
-ENV TINI_VERSION=<%= tini_version %>
-# Options added via tini README.md suggestion
-# https://github.com/krallin/tini#building-tini
-ENV CFLAGS="-DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37"
-
-RUN <<EOT
-#!/usr/bin/env bash
-set -exu
-apt-get update
-apt-get install --yes --no-install-recommends \
-  build-essential \
-  ca-certificates \
-  cmake \
-  curl \
-  golang \
-  make \
-  tar
-update-ca-certificates
-curl -L https://github.com/krallin/tini/archive/refs/tags/$TINI_VERSION.tar.gz -o tini-$TINI_VERSION.tar.gz
-tar -xf tini-$TINI_VERSION.tar.gz
-# Compile tini from source to ensure compatability with the m1 architectures
-cd tini-$(echo $TINI_VERSION | cut -c2-)
-cmake .
-make
-# Ensure tini runs
-./tini-static --version
-mv ./tini-static /tini
-EOT
-
-
 ########## core image ##########################
 FROM <%= base_image %> as core
 LABEL com.opencontainers.image.authors="djbender"
@@ -72,14 +36,8 @@ EOT
 ENV LANG en_US.utf-8
 ENV LANGUAGE en_US:en
 
-# Install Tini for init use (reaps defunct processes and forwards signals)
-COPY --from=tini /tini /tini
-
 # Switch to the 'docker' user
 USER docker
-
-# always use tini
-ENTRYPOINT ["/tini", "--"]
 
 # keep backwards compatability with use cases that assume CMD is 'bash' since
 # specifying an ENTRYPOINT always clears the CMD that was inheritted by the FROM image

--- a/manifest.yml
+++ b/manifest.yml
@@ -21,7 +21,6 @@ globals:
     distribution_code_name: noble
     docker_syntax: docker/dockerfile:1.4  # https://hub.docker.com/r/docker/dockerfile
     ghcr_registry: ghcr.io
-    tini_version: v0.19.0
 
 ############### Image definitions #################################
 


### PR DESCRIPTION
Related to #69, I have a hunch that tini may no longer cross compile via QEMU. However for a very long time the `--init` flag has been available so we might as well just use that!