### PR TITLE
Replace GitHub Actions cache with GHCR registry cache

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -88,17 +88,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push primary images
         uses: docker/bake-action@v6.8.0
         with:
           pull: true
           push: ${{ github.ref == 'refs/heads/main' }}
           files: ${{ matrix.bake }}
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.primary_target }}
           source: .
           set: |
-            ${{ matrix.cache-from }}
-            ${{ matrix.cache-to }}
+            ${{ matrix.primary_cache_from }}
+            ${{ matrix.primary_cache_to }}
+            ${{ matrix.platform }}
+
+      - name: Build and push dev images
+        uses: docker/bake-action@v6.8.0
+        with:
+          pull: true
+          push: ${{ github.ref == 'refs/heads/main' }}
+          files: ${{ matrix.bake }}
+          targets: ${{ matrix.dev_target }}
+          source: .
+          set: |
+            ${{ matrix.dev_cache_from }}
+            ${{ matrix.dev_cache_to }}
             ${{ matrix.platform }}
 
   build-common-images:
@@ -141,15 +154,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push primary images
         uses: docker/bake-action@v6.8.0
         with:
           pull: true
           push: ${{ github.ref == 'refs/heads/main' }}
           files: ${{ matrix.bake }}
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.primary_target }}
           source: .
           set: |
-            ${{ matrix.cache-from }}
-            ${{ matrix.cache-to }}
+            ${{ matrix.primary_cache_from }}
+            ${{ matrix.primary_cache_to }}
+            ${{ matrix.platform }}
+
+      - name: Build and push dev images
+        uses: docker/bake-action@v6.8.0
+        with:
+          pull: true
+          push: ${{ github.ref == 'refs/heads/main' }}
+          files: ${{ matrix.bake }}
+          targets: ${{ matrix.dev_target }}
+          source: .
+          set: |
+            ${{ matrix.dev_cache_from }}
+            ${{ matrix.dev_cache_to }}
             ${{ matrix.platform }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -94,6 +94,7 @@ jobs:
           pull: true
           push: ${{ github.ref == 'refs/heads/main' }}
           files: ${{ matrix.bake }}
+          targets: ${{ matrix.target }}
           source: .
           set: |
             ${{ matrix.cache-from }}
@@ -146,6 +147,7 @@ jobs:
           pull: true
           push: ${{ github.ref == 'refs/heads/main' }}
           files: ${{ matrix.bake }}
+          targets: ${{ matrix.target }}
           source: .
           set: |
             ${{ matrix.cache-from }}

--- a/core/bionic/docker-bake.hcl
+++ b/core/bionic/docker-bake.hcl
@@ -23,14 +23,20 @@ target "core" {
   tags = ["ghcr.io/djbender/core:bionic"]
   context = "${PWD}/core/bionic"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=core/bionic"]
-  cache-to = ["type=gha,scope=core/bionic,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/core:cache-bionic",
+    "type=registry,ref=ghcr.io/djbender/core:bionic"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-bionic,mode=max"]
 }
 
 target "core-dev" {
   target = "core-dev"
   inherits = ["core"]
   tags = ["ghcr.io/djbender/core:bionic-dev"]
-  cache-from = ["type=gha,scope=core-dev/bionic"]
-  cache-to = ["type=gha,scope=core-dev/bionic,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/core:cache-dev-bionic",
+    "type=registry,ref=ghcr.io/djbender/core:dev-bionic"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-dev-bionic,mode=max"]
 }

--- a/core/jammy/docker-bake.hcl
+++ b/core/jammy/docker-bake.hcl
@@ -23,14 +23,20 @@ target "core" {
   tags = ["ghcr.io/djbender/core:jammy"]
   context = "${PWD}/core/jammy"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=core/jammy"]
-  cache-to = ["type=gha,scope=core/jammy,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/core:cache-jammy",
+    "type=registry,ref=ghcr.io/djbender/core:jammy"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-jammy,mode=max"]
 }
 
 target "core-dev" {
   target = "core-dev"
   inherits = ["core"]
   tags = ["ghcr.io/djbender/core:jammy-dev"]
-  cache-from = ["type=gha,scope=core-dev/jammy"]
-  cache-to = ["type=gha,scope=core-dev/jammy,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy",
+    "type=registry,ref=ghcr.io/djbender/core:dev-jammy"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy,mode=max"]
 }

--- a/core/noble/docker-bake.hcl
+++ b/core/noble/docker-bake.hcl
@@ -23,14 +23,20 @@ target "core" {
   tags = ["ghcr.io/djbender/core:latest", "ghcr.io/djbender/core:noble"]
   context = "${PWD}/core/noble"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=core/noble"]
-  cache-to = ["type=gha,scope=core/noble,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/core:cache-noble",
+    "type=registry,ref=ghcr.io/djbender/core:noble"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-noble,mode=max"]
 }
 
 target "core-dev" {
   target = "core-dev"
   inherits = ["core"]
   tags = ["ghcr.io/djbender/core:dev", "ghcr.io/djbender/core:noble-dev"]
-  cache-from = ["type=gha,scope=core-dev/noble"]
-  cache-to = ["type=gha,scope=core-dev/noble,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/core:cache-dev-noble",
+    "type=registry,ref=ghcr.io/djbender/core:dev-noble"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-dev-noble,mode=max"]
 }

--- a/core/template/docker-bake.hcl.erb
+++ b/core/template/docker-bake.hcl.erb
@@ -22,8 +22,11 @@ target "<%= image_name %>" {
   tags = <%= tags %>
   context = "${PWD}/<%= image_name %>/<%= version %>"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=<%= image_name %>/<%= version %>"]
-  cache-to = ["type=gha,scope=<%= image_name %>/<%= version %>,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>,mode=max"]
 }
 <%-
 core_dev_tags = [
@@ -36,6 +39,9 @@ target "<%= image_name %>-dev" {
   target = "<%= image_name %>-dev"
   inherits = ["<%= image_name %>"]
   tags = <%= dev_tags %>
-  cache-from = ["type=gha,scope=<%= image_name %>-dev/<%= version %>"]
-  cache-to = ["type=gha,scope=<%= image_name %>-dev/<%= version %>,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>",
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:dev-<%= version %>"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>,mode=max"]
 }

--- a/lib/metadata.rb
+++ b/lib/metadata.rb
@@ -32,6 +32,11 @@ class Metadata
     default_dev_docker_tags.push(custom_tags).flatten.compact.uniq.sort
   end
 
+  def branch_suffix
+    branch_name = ENV['GITHUB_REF_NAME'] || 'main'
+    branch_name == 'main' ? '' : "-#{branch_name.gsub(/[^a-zA-Z0-9\-_]/, '-')}"
+  end
+
   # return nil if you try to call a method that doesn't exist
   def method_missing(_method_name, *_args, &); end
   def respond_to_missing?(_method_name); end

--- a/node/10/docker-bake.hcl
+++ b/node/10/docker-bake.hcl
@@ -23,10 +23,11 @@ target "node" {
   context = "${PWD}/node/10"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=node/10"
+    "type=registry,ref=ghcr.io/djbender/node:cache-10",
+    "type=registry,ref=ghcr.io/djbender/node:10"
   ]
   cache-to = [
-    "type=gha,scope=node/10,mode=max"
+    "type=registry,ref=ghcr.io/djbender/node:cache-10,mode=max"
   ]
 }
 
@@ -35,6 +36,9 @@ target "node-dev" {
   target = "node-dev"
   inherits = ["node"]
   tags = ["ghcr.io/djbender/node:10-dev", "ghcr.io/djbender/node:10-dev-bionic", "ghcr.io/djbender/node:10.24.1-dev", "ghcr.io/djbender/node:10.24.1-dev-bionic"]
-  cache-from = ["type=gha,scope=node-dev/10"]
-  cache-to = ["type=gha,scope=node-dev/10,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-10",
+    "type=registry,ref=ghcr.io/djbender/node:dev-10"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-10,mode=max"]
 }

--- a/node/12/docker-bake.hcl
+++ b/node/12/docker-bake.hcl
@@ -23,10 +23,11 @@ target "node" {
   context = "${PWD}/node/12"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=node/12"
+    "type=registry,ref=ghcr.io/djbender/node:cache-12",
+    "type=registry,ref=ghcr.io/djbender/node:12"
   ]
   cache-to = [
-    "type=gha,scope=node/12,mode=max"
+    "type=registry,ref=ghcr.io/djbender/node:cache-12,mode=max"
   ]
 }
 
@@ -35,6 +36,9 @@ target "node-dev" {
   target = "node-dev"
   inherits = ["node"]
   tags = ["ghcr.io/djbender/node:12-dev", "ghcr.io/djbender/node:12-dev-bionic", "ghcr.io/djbender/node:12.22.12-dev", "ghcr.io/djbender/node:12.22.12-dev-bionic"]
-  cache-from = ["type=gha,scope=node-dev/12"]
-  cache-to = ["type=gha,scope=node-dev/12,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-12",
+    "type=registry,ref=ghcr.io/djbender/node:dev-12"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-12,mode=max"]
 }

--- a/node/14/docker-bake.hcl
+++ b/node/14/docker-bake.hcl
@@ -23,10 +23,11 @@ target "node" {
   context = "${PWD}/node/14"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=node/14"
+    "type=registry,ref=ghcr.io/djbender/node:cache-14",
+    "type=registry,ref=ghcr.io/djbender/node:14"
   ]
   cache-to = [
-    "type=gha,scope=node/14,mode=max"
+    "type=registry,ref=ghcr.io/djbender/node:cache-14,mode=max"
   ]
 }
 
@@ -35,6 +36,9 @@ target "node-dev" {
   target = "node-dev"
   inherits = ["node"]
   tags = ["ghcr.io/djbender/node:14-dev", "ghcr.io/djbender/node:14-dev-jammy", "ghcr.io/djbender/node:14.21.3-dev", "ghcr.io/djbender/node:14.21.3-dev-jammy"]
-  cache-from = ["type=gha,scope=node-dev/14"]
-  cache-to = ["type=gha,scope=node-dev/14,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-14",
+    "type=registry,ref=ghcr.io/djbender/node:dev-14"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-14,mode=max"]
 }

--- a/node/16/docker-bake.hcl
+++ b/node/16/docker-bake.hcl
@@ -23,10 +23,11 @@ target "node" {
   context = "${PWD}/node/16"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=node/16"
+    "type=registry,ref=ghcr.io/djbender/node:cache-16",
+    "type=registry,ref=ghcr.io/djbender/node:16"
   ]
   cache-to = [
-    "type=gha,scope=node/16,mode=max"
+    "type=registry,ref=ghcr.io/djbender/node:cache-16,mode=max"
   ]
 }
 
@@ -35,6 +36,9 @@ target "node-dev" {
   target = "node-dev"
   inherits = ["node"]
   tags = ["ghcr.io/djbender/node:16-dev", "ghcr.io/djbender/node:16-dev-jammy", "ghcr.io/djbender/node:16.20.2-dev", "ghcr.io/djbender/node:16.20.2-dev-jammy"]
-  cache-from = ["type=gha,scope=node-dev/16"]
-  cache-to = ["type=gha,scope=node-dev/16,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-16",
+    "type=registry,ref=ghcr.io/djbender/node:dev-16"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-16,mode=max"]
 }

--- a/node/18/docker-bake.hcl
+++ b/node/18/docker-bake.hcl
@@ -23,10 +23,11 @@ target "node" {
   context = "${PWD}/node/18"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=node/18"
+    "type=registry,ref=ghcr.io/djbender/node:cache-18",
+    "type=registry,ref=ghcr.io/djbender/node:18"
   ]
   cache-to = [
-    "type=gha,scope=node/18,mode=max"
+    "type=registry,ref=ghcr.io/djbender/node:cache-18,mode=max"
   ]
 }
 
@@ -35,6 +36,9 @@ target "node-dev" {
   target = "node-dev"
   inherits = ["node"]
   tags = ["ghcr.io/djbender/node:18-dev", "ghcr.io/djbender/node:18-dev-noble", "ghcr.io/djbender/node:18.20.8-dev", "ghcr.io/djbender/node:18.20.8-dev-noble"]
-  cache-from = ["type=gha,scope=node-dev/18"]
-  cache-to = ["type=gha,scope=node-dev/18,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-18",
+    "type=registry,ref=ghcr.io/djbender/node:dev-18"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-18,mode=max"]
 }

--- a/node/20/docker-bake.hcl
+++ b/node/20/docker-bake.hcl
@@ -23,10 +23,11 @@ target "node" {
   context = "${PWD}/node/20"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=node/20"
+    "type=registry,ref=ghcr.io/djbender/node:cache-20",
+    "type=registry,ref=ghcr.io/djbender/node:20"
   ]
   cache-to = [
-    "type=gha,scope=node/20,mode=max"
+    "type=registry,ref=ghcr.io/djbender/node:cache-20,mode=max"
   ]
 }
 
@@ -35,6 +36,9 @@ target "node-dev" {
   target = "node-dev"
   inherits = ["node"]
   tags = ["ghcr.io/djbender/node:20-dev", "ghcr.io/djbender/node:20-dev-noble", "ghcr.io/djbender/node:20.19.4-dev", "ghcr.io/djbender/node:20.19.4-dev-noble"]
-  cache-from = ["type=gha,scope=node-dev/20"]
-  cache-to = ["type=gha,scope=node-dev/20,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-20",
+    "type=registry,ref=ghcr.io/djbender/node:dev-20"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-20,mode=max"]
 }

--- a/node/22/docker-bake.hcl
+++ b/node/22/docker-bake.hcl
@@ -23,10 +23,11 @@ target "node" {
   context = "${PWD}/node/22"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=node/22"
+    "type=registry,ref=ghcr.io/djbender/node:cache-22",
+    "type=registry,ref=ghcr.io/djbender/node:22"
   ]
   cache-to = [
-    "type=gha,scope=node/22,mode=max"
+    "type=registry,ref=ghcr.io/djbender/node:cache-22,mode=max"
   ]
 }
 
@@ -35,6 +36,9 @@ target "node-dev" {
   target = "node-dev"
   inherits = ["node"]
   tags = ["ghcr.io/djbender/node:22-dev", "ghcr.io/djbender/node:22-dev-noble", "ghcr.io/djbender/node:22.18.0-dev", "ghcr.io/djbender/node:22.18.0-dev-noble"]
-  cache-from = ["type=gha,scope=node-dev/22"]
-  cache-to = ["type=gha,scope=node-dev/22,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-22",
+    "type=registry,ref=ghcr.io/djbender/node:dev-22"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-22,mode=max"]
 }

--- a/node/23/docker-bake.hcl
+++ b/node/23/docker-bake.hcl
@@ -23,10 +23,11 @@ target "node" {
   context = "${PWD}/node/23"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=node/23"
+    "type=registry,ref=ghcr.io/djbender/node:cache-23",
+    "type=registry,ref=ghcr.io/djbender/node:23"
   ]
   cache-to = [
-    "type=gha,scope=node/23,mode=max"
+    "type=registry,ref=ghcr.io/djbender/node:cache-23,mode=max"
   ]
 }
 
@@ -35,6 +36,9 @@ target "node-dev" {
   target = "node-dev"
   inherits = ["node"]
   tags = ["ghcr.io/djbender/node:23-dev", "ghcr.io/djbender/node:23-dev-noble", "ghcr.io/djbender/node:23.11.1-dev", "ghcr.io/djbender/node:23.11.1-dev-noble"]
-  cache-from = ["type=gha,scope=node-dev/23"]
-  cache-to = ["type=gha,scope=node-dev/23,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-23",
+    "type=registry,ref=ghcr.io/djbender/node:dev-23"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-23,mode=max"]
 }

--- a/node/24/docker-bake.hcl
+++ b/node/24/docker-bake.hcl
@@ -23,10 +23,11 @@ target "node" {
   context = "${PWD}/node/24"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=node/24"
+    "type=registry,ref=ghcr.io/djbender/node:cache-24",
+    "type=registry,ref=ghcr.io/djbender/node:24"
   ]
   cache-to = [
-    "type=gha,scope=node/24,mode=max"
+    "type=registry,ref=ghcr.io/djbender/node:cache-24,mode=max"
   ]
 }
 
@@ -35,6 +36,9 @@ target "node-dev" {
   target = "node-dev"
   inherits = ["node"]
   tags = ["ghcr.io/djbender/node:24-dev", "ghcr.io/djbender/node:24-dev-noble", "ghcr.io/djbender/node:24.5.0-dev", "ghcr.io/djbender/node:24.5.0-dev-noble", "ghcr.io/djbender/node:dev"]
-  cache-from = ["type=gha,scope=node-dev/24"]
-  cache-to = ["type=gha,scope=node-dev/24,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-24",
+    "type=registry,ref=ghcr.io/djbender/node:dev-24"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-24,mode=max"]
 }

--- a/node/8/docker-bake.hcl
+++ b/node/8/docker-bake.hcl
@@ -23,10 +23,11 @@ target "node" {
   context = "${PWD}/node/8"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=node/8"
+    "type=registry,ref=ghcr.io/djbender/node:cache-8",
+    "type=registry,ref=ghcr.io/djbender/node:8"
   ]
   cache-to = [
-    "type=gha,scope=node/8,mode=max"
+    "type=registry,ref=ghcr.io/djbender/node:cache-8,mode=max"
   ]
 }
 
@@ -35,6 +36,9 @@ target "node-dev" {
   target = "node-dev"
   inherits = ["node"]
   tags = ["ghcr.io/djbender/node:8-dev", "ghcr.io/djbender/node:8-dev-bionic", "ghcr.io/djbender/node:8.17.0-dev", "ghcr.io/djbender/node:8.17.0-dev-bionic"]
-  cache-from = ["type=gha,scope=node-dev/8"]
-  cache-to = ["type=gha,scope=node-dev/8,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-8",
+    "type=registry,ref=ghcr.io/djbender/node:dev-8"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-8,mode=max"]
 }

--- a/node/template/docker-bake.hcl.erb
+++ b/node/template/docker-bake.hcl.erb
@@ -29,10 +29,11 @@ target "<%= image_name %>" {
   context = "${PWD}/<%= image_name %>/<%= version %>"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [
-    "type=gha,scope=<%= image_name %>/<%= version %>"
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"
   ]
   cache-to = [
-    "type=gha,scope=<%= image_name %>/<%= version %>,mode=max"
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>,mode=max"
   ]
 }
 
@@ -49,6 +50,9 @@ target "<%= image_name %>-dev" {
   target = "<%= image_name %>-dev"
   inherits = ["<%= image_name %>"]
   tags = <%= dev_tags %>
-  cache-from = ["type=gha,scope=<%= image_name %>-dev/<%= version %>"]
-  cache-to = ["type=gha,scope=<%= image_name %>-dev/<%= version %>,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>",
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:dev-<%= version %>"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>,mode=max"]
 }

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -54,10 +54,11 @@ def matrix(&)
         {
           bake: Pathname.new("#{image_name}/#{version}") + Util::BAKE_FILE,
           'cache-from' => [
-            "*.cache-from=type=gha,scope=#{image_name}/#{version}"
+            "*.cache-from=type=registry,ref=ghcr.io/djbender/#{image_name}:cache-#{version}",
+            "*.cache-from=type=registry,ref=ghcr.io/djbender/#{image_name}:#{version}"
           ].join("\n"),
           'cache-to' => [
-            "*.cache-to=type=gha,scope=#{image_name}/#{version},mode=max"
+            "*.cache-to=type=registry,ref=ghcr.io/djbender/#{image_name}:cache-#{version},mode=max"
           ].join("\n"),
           'platform' => platform.join("\n")
         }

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -71,22 +71,17 @@ def matrix(&)
         end
 
         [
-          # Primary image configuration
+          # Combined matrix entry with separate target and cache configurations
           {
             bake: Pathname.new("#{image_name}/#{version}") + Util::BAKE_FILE,
-            target: image_name,
-            'cache-from' => primary_cache_from.join("\n"),
-            'cache-to' => [
+            primary_target: image_name,
+            dev_target: "#{image_name}-dev",
+            primary_cache_from: primary_cache_from.join("\n"),
+            primary_cache_to: [
               "#{image_name}.cache-to=type=registry,ref=ghcr.io/djbender/#{image_name}:cache-#{version}#{branch_suffix},mode=max"
             ].join("\n"),
-            'platform' => platform.join("\n")
-          },
-          # Dev image configuration
-          {
-            bake: Pathname.new("#{image_name}/#{version}") + Util::BAKE_FILE,
-            target: "#{image_name}-dev",
-            'cache-from' => dev_cache_from.join("\n"),
-            'cache-to' => [
+            dev_cache_from: dev_cache_from.join("\n"),
+            dev_cache_to: [
               "#{image_name}-dev.cache-to=type=registry,ref=ghcr.io/djbender/#{image_name}:cache-dev-#{version}#{branch_suffix},mode=max"
             ].join("\n"),
             'platform' => platform.join("\n")

--- a/ruby/2.4/docker-bake.hcl
+++ b/ruby/2.4/docker-bake.hcl
@@ -22,14 +22,20 @@ target "ruby" {
   tags = ["ghcr.io/djbender/ruby:2.4", "ghcr.io/djbender/ruby:2.4-bionic", "ghcr.io/djbender/ruby:2.4.10", "ghcr.io/djbender/ruby:2.4.10-bionic"]
   context = "${PWD}/ruby/2.4"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=ruby/2.4"]
-  cache-to = ["type=gha,scope=ruby/2.4,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.4",
+    "type=registry,ref=ghcr.io/djbender/ruby:2.4"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.4,mode=max"]
 }
 
 target "ruby-dev" {
   target = "ruby-dev"
   inherits = ["ruby"]
   tags = ["ghcr.io/djbender/ruby:2.4-dev-bionic", "ghcr.io/djbender/ruby:2.4.10-dev", "ghcr.io/djbender/ruby:2.4.10-dev-bionic"]
-  cache-from = ["type=gha,scope=ruby-dev/2.4"]
-  cache-to = ["type=gha,scope=ruby-dev/2.4,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.4",
+    "type=registry,ref=ghcr.io/djbender/ruby:dev-2.4"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.4,mode=max"]
 }

--- a/ruby/2.5/docker-bake.hcl
+++ b/ruby/2.5/docker-bake.hcl
@@ -22,14 +22,20 @@ target "ruby" {
   tags = ["ghcr.io/djbender/ruby:2.5", "ghcr.io/djbender/ruby:2.5-bionic", "ghcr.io/djbender/ruby:2.5.9", "ghcr.io/djbender/ruby:2.5.9-bionic"]
   context = "${PWD}/ruby/2.5"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=ruby/2.5"]
-  cache-to = ["type=gha,scope=ruby/2.5,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.5",
+    "type=registry,ref=ghcr.io/djbender/ruby:2.5"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.5,mode=max"]
 }
 
 target "ruby-dev" {
   target = "ruby-dev"
   inherits = ["ruby"]
   tags = ["ghcr.io/djbender/ruby:2.5-dev-bionic", "ghcr.io/djbender/ruby:2.5.9-dev", "ghcr.io/djbender/ruby:2.5.9-dev-bionic"]
-  cache-from = ["type=gha,scope=ruby-dev/2.5"]
-  cache-to = ["type=gha,scope=ruby-dev/2.5,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.5",
+    "type=registry,ref=ghcr.io/djbender/ruby:dev-2.5"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.5,mode=max"]
 }

--- a/ruby/2.6/docker-bake.hcl
+++ b/ruby/2.6/docker-bake.hcl
@@ -22,14 +22,20 @@ target "ruby" {
   tags = ["ghcr.io/djbender/ruby:2.6", "ghcr.io/djbender/ruby:2.6-bionic", "ghcr.io/djbender/ruby:2.6.10", "ghcr.io/djbender/ruby:2.6.10-bionic"]
   context = "${PWD}/ruby/2.6"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=ruby/2.6"]
-  cache-to = ["type=gha,scope=ruby/2.6,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.6",
+    "type=registry,ref=ghcr.io/djbender/ruby:2.6"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.6,mode=max"]
 }
 
 target "ruby-dev" {
   target = "ruby-dev"
   inherits = ["ruby"]
   tags = ["ghcr.io/djbender/ruby:2.6-dev-bionic", "ghcr.io/djbender/ruby:2.6.10-dev", "ghcr.io/djbender/ruby:2.6.10-dev-bionic"]
-  cache-from = ["type=gha,scope=ruby-dev/2.6"]
-  cache-to = ["type=gha,scope=ruby-dev/2.6,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.6",
+    "type=registry,ref=ghcr.io/djbender/ruby:dev-2.6"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.6,mode=max"]
 }

--- a/ruby/2.7/docker-bake.hcl
+++ b/ruby/2.7/docker-bake.hcl
@@ -22,14 +22,20 @@ target "ruby" {
   tags = ["ghcr.io/djbender/ruby:2.7", "ghcr.io/djbender/ruby:2.7-noble", "ghcr.io/djbender/ruby:2.7.8", "ghcr.io/djbender/ruby:2.7.8-noble"]
   context = "${PWD}/ruby/2.7"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=ruby/2.7"]
-  cache-to = ["type=gha,scope=ruby/2.7,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.7",
+    "type=registry,ref=ghcr.io/djbender/ruby:2.7"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.7,mode=max"]
 }
 
 target "ruby-dev" {
   target = "ruby-dev"
   inherits = ["ruby"]
   tags = ["ghcr.io/djbender/ruby:2.7-dev-noble", "ghcr.io/djbender/ruby:2.7.8-dev", "ghcr.io/djbender/ruby:2.7.8-dev-noble"]
-  cache-from = ["type=gha,scope=ruby-dev/2.7"]
-  cache-to = ["type=gha,scope=ruby-dev/2.7,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.7",
+    "type=registry,ref=ghcr.io/djbender/ruby:dev-2.7"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.7,mode=max"]
 }

--- a/ruby/3.0/docker-bake.hcl
+++ b/ruby/3.0/docker-bake.hcl
@@ -22,14 +22,20 @@ target "ruby" {
   tags = ["ghcr.io/djbender/ruby:3.0", "ghcr.io/djbender/ruby:3.0-noble", "ghcr.io/djbender/ruby:3.0.7", "ghcr.io/djbender/ruby:3.0.7-noble"]
   context = "${PWD}/ruby/3.0"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=ruby/3.0"]
-  cache-to = ["type=gha,scope=ruby/3.0,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.0",
+    "type=registry,ref=ghcr.io/djbender/ruby:3.0"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.0,mode=max"]
 }
 
 target "ruby-dev" {
   target = "ruby-dev"
   inherits = ["ruby"]
   tags = ["ghcr.io/djbender/ruby:3.0-dev-noble", "ghcr.io/djbender/ruby:3.0.7-dev", "ghcr.io/djbender/ruby:3.0.7-dev-noble"]
-  cache-from = ["type=gha,scope=ruby-dev/3.0"]
-  cache-to = ["type=gha,scope=ruby-dev/3.0,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.0",
+    "type=registry,ref=ghcr.io/djbender/ruby:dev-3.0"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.0,mode=max"]
 }

--- a/ruby/3.1/docker-bake.hcl
+++ b/ruby/3.1/docker-bake.hcl
@@ -22,14 +22,20 @@ target "ruby" {
   tags = ["ghcr.io/djbender/ruby:3.1", "ghcr.io/djbender/ruby:3.1-noble", "ghcr.io/djbender/ruby:3.1.7", "ghcr.io/djbender/ruby:3.1.7-noble"]
   context = "${PWD}/ruby/3.1"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=ruby/3.1"]
-  cache-to = ["type=gha,scope=ruby/3.1,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.1",
+    "type=registry,ref=ghcr.io/djbender/ruby:3.1"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.1,mode=max"]
 }
 
 target "ruby-dev" {
   target = "ruby-dev"
   inherits = ["ruby"]
   tags = ["ghcr.io/djbender/ruby:3.1-dev-noble", "ghcr.io/djbender/ruby:3.1.7-dev", "ghcr.io/djbender/ruby:3.1.7-dev-noble"]
-  cache-from = ["type=gha,scope=ruby-dev/3.1"]
-  cache-to = ["type=gha,scope=ruby-dev/3.1,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.1",
+    "type=registry,ref=ghcr.io/djbender/ruby:dev-3.1"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.1,mode=max"]
 }

--- a/ruby/3.2/docker-bake.hcl
+++ b/ruby/3.2/docker-bake.hcl
@@ -22,14 +22,20 @@ target "ruby" {
   tags = ["ghcr.io/djbender/ruby:3.2", "ghcr.io/djbender/ruby:3.2-noble", "ghcr.io/djbender/ruby:3.2.8", "ghcr.io/djbender/ruby:3.2.8-noble"]
   context = "${PWD}/ruby/3.2"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=ruby/3.2"]
-  cache-to = ["type=gha,scope=ruby/3.2,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.2",
+    "type=registry,ref=ghcr.io/djbender/ruby:3.2"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.2,mode=max"]
 }
 
 target "ruby-dev" {
   target = "ruby-dev"
   inherits = ["ruby"]
   tags = ["ghcr.io/djbender/ruby:3.2-dev-noble", "ghcr.io/djbender/ruby:3.2.8-dev", "ghcr.io/djbender/ruby:3.2.8-dev-noble"]
-  cache-from = ["type=gha,scope=ruby-dev/3.2"]
-  cache-to = ["type=gha,scope=ruby-dev/3.2,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.2",
+    "type=registry,ref=ghcr.io/djbender/ruby:dev-3.2"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.2,mode=max"]
 }

--- a/ruby/3.3/docker-bake.hcl
+++ b/ruby/3.3/docker-bake.hcl
@@ -22,14 +22,20 @@ target "ruby" {
   tags = ["ghcr.io/djbender/ruby:3.3", "ghcr.io/djbender/ruby:3.3-noble", "ghcr.io/djbender/ruby:3.3.8", "ghcr.io/djbender/ruby:3.3.8-noble"]
   context = "${PWD}/ruby/3.3"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=ruby/3.3"]
-  cache-to = ["type=gha,scope=ruby/3.3,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.3",
+    "type=registry,ref=ghcr.io/djbender/ruby:3.3"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.3,mode=max"]
 }
 
 target "ruby-dev" {
   target = "ruby-dev"
   inherits = ["ruby"]
   tags = ["ghcr.io/djbender/ruby:3.3-dev-noble", "ghcr.io/djbender/ruby:3.3.8-dev", "ghcr.io/djbender/ruby:3.3.8-dev-noble"]
-  cache-from = ["type=gha,scope=ruby-dev/3.3"]
-  cache-to = ["type=gha,scope=ruby-dev/3.3,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.3",
+    "type=registry,ref=ghcr.io/djbender/ruby:dev-3.3"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.3,mode=max"]
 }

--- a/ruby/3.4/docker-bake.hcl
+++ b/ruby/3.4/docker-bake.hcl
@@ -22,14 +22,20 @@ target "ruby" {
   tags = ["ghcr.io/djbender/ruby:3.4", "ghcr.io/djbender/ruby:3.4-noble", "ghcr.io/djbender/ruby:3.4.3", "ghcr.io/djbender/ruby:3.4.3-noble", "ghcr.io/djbender/ruby:latest"]
   context = "${PWD}/ruby/3.4"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=ruby/3.4"]
-  cache-to = ["type=gha,scope=ruby/3.4,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.4",
+    "type=registry,ref=ghcr.io/djbender/ruby:3.4"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.4,mode=max"]
 }
 
 target "ruby-dev" {
   target = "ruby-dev"
   inherits = ["ruby"]
   tags = ["ghcr.io/djbender/ruby:3.4-dev-noble", "ghcr.io/djbender/ruby:3.4.3-dev", "ghcr.io/djbender/ruby:3.4.3-dev-noble", "ghcr.io/djbender/ruby:dev"]
-  cache-from = ["type=gha,scope=ruby-dev/3.4"]
-  cache-to = ["type=gha,scope=ruby-dev/3.4,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.4",
+    "type=registry,ref=ghcr.io/djbender/ruby:dev-3.4"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.4,mode=max"]
 }

--- a/ruby/template/docker-bake.hcl.erb
+++ b/ruby/template/docker-bake.hcl.erb
@@ -27,8 +27,11 @@ target "<%= image_name %>" {
   tags = <%= custom_tags %>
   context = "${PWD}/<%= image_name %>/<%= version %>"
   platforms = ["linux/amd64", "linux/arm64"]
-  cache-from = ["type=gha,scope=<%= image_name %>/<%= version %>"]
-  cache-to = ["type=gha,scope=<%= image_name %>/<%= version %>,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>,mode=max"]
 }
 <%-
 ruby_dev_tags = []
@@ -42,6 +45,9 @@ target "<%= image_name %>-dev" {
   target = "<%= image_name %>-dev"
   inherits = ["<%= image_name %>"]
   tags = <%= dev_tags %>
-  cache-from = ["type=gha,scope=<%= image_name %>-dev/<%= version %>"]
-  cache-to = ["type=gha,scope=<%= image_name %>-dev/<%= version %>,mode=max"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>",
+    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:dev-<%= version %>"
+  ]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>,mode=max"]
 }


### PR DESCRIPTION
## Summary

Improve Docker image caching strategy by replacing GitHub Actions cache with GitHub Container Registry (GHCR) cache and implementing branch-specific caching.

- **Replace GitHub Actions cache with GHCR registry cache** for better performance and reliability
- **Split bake targets with branch-specific caching** to optimize build times across different branches
- **Fix target dependency with sequential bake steps** to ensure proper build order

## Changes

- Updated GitHub Actions workflow to use GHCR instead of Actions cache
- Modified all `docker-bake.hcl` files across core, node, and ruby images to implement new caching strategy
- Enhanced CI rake tasks to support branch-specific cache configuration
- Added metadata handling for improved cache key generation