### PR TITLE
Docker buildx install option was deprecated and not necessary

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -69,8 +69,6 @@ jobs:
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3.12.0
-        with:
-          install: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3.7.0
@@ -131,8 +129,6 @@ jobs:
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3.12.0
-        with:
-          install: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3.7.0


### PR DESCRIPTION
ref: docker/setup-buildx-action#455