### PR TITLE
Centralize platforms config in manifest.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Node 23
 
 ### Changed
+- Centralize `platforms` config in `manifest.yml` globals (previously hardcoded in templates)
 - Node 25: 25.3.0 → 25.6.0
 - dependabot.yml updated for node version changes
 - .rubocop.yml migrated from `require` to `plugins` syntax

--- a/core/template/docker-bake.hcl.erb
+++ b/core/template/docker-bake.hcl.erb
@@ -16,7 +16,7 @@ target "<%= image_name %>" {
   target = "<%= image_name %>"
   tags = <%= docker_tags %>
   context = "${PWD}/<%= image_name %>/<%= version %>"
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = <%= platforms.inspect %>
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"

--- a/core/template/docker-bake.hcl.erb
+++ b/core/template/docker-bake.hcl.erb
@@ -16,7 +16,7 @@ target "<%= image_name %>" {
   target = "<%= image_name %>"
   tags = <%= docker_tags %>
   context = "${PWD}/<%= image_name %>/<%= version %>"
-  platforms = <%= platforms.inspect %>
+  platforms = <%= platforms %>
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,6 +11,7 @@
 #     '3':
 #       sqlite_version: 2 # overrides the 3 from defaults above
 #       additional_tags: foo:latest # Adds additonal tags to docker-bake.hcl
+#       platforms: [linux/amd64] # override global platforms for this version
 
 # Define global defaults here, that apply to all images.
 # Can be overriden by image specific defaults
@@ -21,6 +22,9 @@ globals:
     distribution_code_name: noble
     docker_syntax: docker/dockerfile:1.4  # https://hub.docker.com/r/docker/dockerfile
     ghcr_registry: ghcr.io
+    platforms:
+      - linux/amd64
+      - linux/arm64
 
 ############### Image definitions #################################
 

--- a/node/template/docker-bake.hcl.erb
+++ b/node/template/docker-bake.hcl.erb
@@ -16,7 +16,7 @@ target "<%= image_name %>" {
   target = "<%= image_name %>"
   tags = <%= docker_tags %>
   context = "${PWD}/<%= image_name %>/<%= version %>"
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = <%= platforms.inspect %>
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"

--- a/node/template/docker-bake.hcl.erb
+++ b/node/template/docker-bake.hcl.erb
@@ -16,7 +16,7 @@ target "<%= image_name %>" {
   target = "<%= image_name %>"
   tags = <%= docker_tags %>
   context = "${PWD}/<%= image_name %>/<%= version %>"
-  platforms = <%= platforms.inspect %>
+  platforms = <%= platforms %>
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"

--- a/ruby/template/docker-bake.hcl.erb
+++ b/ruby/template/docker-bake.hcl.erb
@@ -16,7 +16,7 @@ target "<%= image_name %>" {
   target = "<%= image_name %>"
   tags = <%= docker_tags %>
   context = "${PWD}/<%= image_name %>/<%= version %>"
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = <%= platforms.inspect %>
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"

--- a/ruby/template/docker-bake.hcl.erb
+++ b/ruby/template/docker-bake.hcl.erb
@@ -16,7 +16,7 @@ target "<%= image_name %>" {
   target = "<%= image_name %>"
   tags = <%= docker_tags %>
   context = "${PWD}/<%= image_name %>/<%= version %>"
-  platforms = <%= platforms.inspect %>
+  platforms = <%= platforms %>
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
     "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"


### PR DESCRIPTION
## Summary
- Move hardcoded `platforms` from templates to `globals.defaults` in manifest.yml
- Templates now use `platforms.inspect` to render the array
- Per-version override supported via standard manifest merge (documented in example comment)

Fixes #249