### PR TITLE
Centralize registry config in manifest.yml

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -10,10 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_OWNER: djbender
-
 jobs:
   set-matrix:
     runs-on: ubuntu-latest
@@ -94,7 +90,7 @@ jobs:
             ${{ matrix.primary_cache_from }}
             ${{ matrix.primary_cache_to }}
             *.platform=${{ matrix.platform }}
-            *.tags=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.primary_target }}:${{ matrix.version }}-${{ github.run_id }}-${{ matrix.arch }}
+            *.tags=${{ matrix.registry }}/${{ matrix.primary_target }}:${{ matrix.version }}-${{ github.run_id }}-${{ matrix.arch }}
 
       - name: Build and push dev images
         uses: docker/bake-action@v6.10.0
@@ -108,7 +104,7 @@ jobs:
             ${{ matrix.dev_cache_from }}
             ${{ matrix.dev_cache_to }}
             *.platform=${{ matrix.platform }}
-            *.tags=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.primary_target }}:${{ matrix.version }}-dev-${{ github.run_id }}-${{ matrix.arch }}
+            *.tags=${{ matrix.registry }}/${{ matrix.primary_target }}:${{ matrix.version }}-dev-${{ github.run_id }}-${{ matrix.arch }}
 
   merge-core-manifests:
     runs-on: ubuntu-slim
@@ -123,7 +119,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set-matrix.outputs.core_merge_matrix) }}
     env:
-      IMAGE_BASE: ghcr.io/djbender/${{ matrix.primary_target }}:${{ matrix.version }}
+      IMAGE_BASE: ${{ matrix.registry }}/${{ matrix.primary_target }}:${{ matrix.version }}
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3.7.0
@@ -186,7 +182,7 @@ jobs:
             ${{ matrix.primary_cache_from }}
             ${{ matrix.primary_cache_to }}
             *.platform=${{ matrix.platform }}
-            *.tags=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.primary_target }}:${{ matrix.version }}-${{ github.run_id }}-${{ matrix.arch }}
+            *.tags=${{ matrix.registry }}/${{ matrix.primary_target }}:${{ matrix.version }}-${{ github.run_id }}-${{ matrix.arch }}
 
       - name: Build and push dev images
         uses: docker/bake-action@v6.10.0
@@ -200,7 +196,7 @@ jobs:
             ${{ matrix.dev_cache_from }}
             ${{ matrix.dev_cache_to }}
             *.platform=${{ matrix.platform }}
-            *.tags=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.primary_target }}:${{ matrix.version }}-dev-${{ github.run_id }}-${{ matrix.arch }}
+            *.tags=${{ matrix.registry }}/${{ matrix.primary_target }}:${{ matrix.version }}-dev-${{ github.run_id }}-${{ matrix.arch }}
 
   merge-common-manifests:
     runs-on: ubuntu-slim
@@ -215,7 +211,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set-matrix.outputs.common_merge_matrix) }}
     env:
-      IMAGE_BASE: ghcr.io/djbender/${{ matrix.primary_target }}:${{ matrix.version }}
+      IMAGE_BASE: ${{ matrix.registry }}/${{ matrix.primary_target }}:${{ matrix.version }}
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3.7.0

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Node 23
 
 ### Changed
+- Centralize registry config: `ghcr.io/djbender` now defined once in `manifest.yml` globals (#250)
 - Centralize `platforms` config in `manifest.yml` globals (previously hardcoded in templates)
 - Node 25: 25.3.0 → 25.6.0
 - dependabot.yml updated for node version changes

--- a/core/template/docker-bake.hcl.erb
+++ b/core/template/docker-bake.hcl.erb
@@ -18,10 +18,10 @@ target "<%= image_name %>" {
   context = "${PWD}/<%= image_name %>/<%= version %>"
   platforms = <%= platforms %>
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"
+    "type=registry,ref=<%= registry %>/<%= image_name %>:cache-<%= version %>",
+    "type=registry,ref=<%= registry %>/<%= image_name %>:<%= version %>"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>,mode=max"]
+  cache-to = ["type=registry,ref=<%= registry %>/<%= image_name %>:cache-<%= version %>,mode=max"]
 }
 
 target "<%= image_name %>-dev" {
@@ -29,8 +29,8 @@ target "<%= image_name %>-dev" {
   inherits = ["<%= image_name %>"]
   tags = <%= docker_dev_tags %>
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>",
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:dev-<%= version %>"
+    "type=registry,ref=<%= registry %>/<%= image_name %>:cache-dev-<%= version %>",
+    "type=registry,ref=<%= registry %>/<%= image_name %>:dev-<%= version %>"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>,mode=max"]
+  cache-to = ["type=registry,ref=<%= registry %>/<%= image_name %>:cache-dev-<%= version %>,mode=max"]
 }

--- a/lib/tag_generator.rb
+++ b/lib/tag_generator.rb
@@ -1,7 +1,9 @@
+require_relative 'util'
+
 # Centralized tag generation for Docker images
 # Used by both ERB templates and CI matrix generation
 module TagGenerator
-  REGISTRY = 'ghcr.io/djbender'.freeze
+  REGISTRY = Util::REGISTRY
 
   class << self
     # Generate primary (non-dev) tags for an image

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -12,6 +12,7 @@ class Util
 
   # Get global defaults, and delete from yml so they are not translated into a docker image
   GLOBAL_DEFAULTS = MANIFEST.delete('globals')
+  REGISTRY = GLOBAL_DEFAULTS.fetch('defaults').fetch('registry').freeze
 
   # Used by Util#with_clean_output_dir to build out paths
   # example:

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,6 +12,7 @@
 #       sqlite_version: 2 # overrides the 3 from defaults above
 #       additional_tags: foo:latest # Adds additonal tags to docker-bake.hcl
 #       platforms: [linux/amd64] # override global platforms for this version
+#       base_image: "%{registry}/core:jammy" # %{registry} interpolated at generation time
 
 # Define global defaults here, that apply to all images.
 # Can be overriden by image specific defaults
@@ -21,10 +22,10 @@ globals:
     base_image: ubuntu:noble
     distribution_code_name: noble
     docker_syntax: docker/dockerfile:1.4  # https://hub.docker.com/r/docker/dockerfile
-    ghcr_registry: ghcr.io
     platforms:
       - linux/amd64
       - linux/arm64
+    registry: ghcr.io/djbender  # combined registry+owner, single source of truth
 
 ############### Image definitions #################################
 
@@ -50,11 +51,11 @@ core:
 # NOTE: Yarn defaults to v1 since I don't believe we use anything later than that
 node: &NODE
   defaults:
-    base_image: ghcr.io/djbender/core
+    base_image: "%{registry}/core"
     yarn_version: 1.22.22
   versions:
     '16': &NODE16
-      base_image: ghcr.io/djbender/core:jammy
+      base_image: "%{registry}/core:jammy"
       distribution_code_name: jammy
       node_major: 16
       node_version: 16.20.2
@@ -83,12 +84,12 @@ node: &NODE
 
 ruby: &RUBY
   defaults:
-    base_image: ghcr.io/djbender/core
+    base_image: "%{registry}/core"
     bundler_version: 2.5.14
     rubygems_version: 3.5.14
   versions:
     '2.4':
-      base_image: ghcr.io/djbender/core:bionic
+      base_image: "%{registry}/core:bionic"
       distribution_code_name: bionic
       ruby_major: 2.4
       ruby_version: 2.4.10
@@ -96,7 +97,7 @@ ruby: &RUBY
       bundler_version: 2.3.27
       rubygems_version: 3.3.27
     '2.5':
-      base_image: ghcr.io/djbender/core:bionic
+      base_image: "%{registry}/core:bionic"
       distribution_code_name: bionic
       ruby_major: 2.5
       ruby_version: 2.5.9
@@ -104,7 +105,7 @@ ruby: &RUBY
       bundler_version: 2.3.27
       rubygems_version: 3.3.27
     '2.6':
-      base_image: ghcr.io/djbender/core:bionic
+      base_image: "%{registry}/core:bionic"
       distribution_code_name: bionic
       ruby_major: 2.6
       ruby_version: 2.6.10

--- a/node/template/docker-bake.hcl.erb
+++ b/node/template/docker-bake.hcl.erb
@@ -18,11 +18,11 @@ target "<%= image_name %>" {
   context = "${PWD}/<%= image_name %>/<%= version %>"
   platforms = <%= platforms %>
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"
+    "type=registry,ref=<%= registry %>/<%= image_name %>:cache-<%= version %>",
+    "type=registry,ref=<%= registry %>/<%= image_name %>:<%= version %>"
   ]
   cache-to = [
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>,mode=max"
+    "type=registry,ref=<%= registry %>/<%= image_name %>:cache-<%= version %>,mode=max"
   ]
 }
 
@@ -31,8 +31,8 @@ target "<%= image_name %>-dev" {
   inherits = ["<%= image_name %>"]
   tags = <%= docker_dev_tags %>
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>",
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:dev-<%= version %>"
+    "type=registry,ref=<%= registry %>/<%= image_name %>:cache-dev-<%= version %>",
+    "type=registry,ref=<%= registry %>/<%= image_name %>:dev-<%= version %>"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>,mode=max"]
+  cache-to = ["type=registry,ref=<%= registry %>/<%= image_name %>:cache-dev-<%= version %>,mode=max"]
 }

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -65,20 +65,20 @@ def matrix(&)
           # Build cache refs
           cache_tag = "#{version}-#{arch_suffix}"
           cache_tag_branch = "#{cache_tag}#{branch_suffix}"
-          registry = "ghcr.io/djbender/#{image_name}"
+          cache_registry = "#{Util::REGISTRY}/#{image_name}"
 
           if main_branch?
-            primary_cache_from = [cache_from_ref(image_name, registry, cache_tag)]
-            dev_cache_from = [cache_from_ref("#{image_name}-dev", registry, "dev-#{cache_tag}")]
+            primary_cache_from = [cache_from_ref(image_name, cache_registry, cache_tag)]
+            dev_cache_from = [cache_from_ref("#{image_name}-dev", cache_registry, "dev-#{cache_tag}")]
           else
             # Feature branch: branch+arch cache with fallback to main arch cache
             primary_cache_from = [
-              cache_from_ref(image_name, registry, cache_tag_branch),
-              cache_from_ref(image_name, registry, cache_tag)
+              cache_from_ref(image_name, cache_registry, cache_tag_branch),
+              cache_from_ref(image_name, cache_registry, cache_tag)
             ]
             dev_cache_from = [
-              cache_from_ref("#{image_name}-dev", registry, "dev-#{cache_tag_branch}"),
-              cache_from_ref("#{image_name}-dev", registry, "dev-#{cache_tag}")
+              cache_from_ref("#{image_name}-dev", cache_registry, "dev-#{cache_tag_branch}"),
+              cache_from_ref("#{image_name}-dev", cache_registry, "dev-#{cache_tag}")
             ]
           end
 
@@ -90,10 +90,11 @@ def matrix(&)
             platform: platform,
             arch: arch_suffix,
             runner: runner,
+            registry: Util::REGISTRY,
             primary_cache_from: primary_cache_from.join("\n"),
-            primary_cache_to: cache_to_ref(image_name, registry, cache_tag_branch),
+            primary_cache_to: cache_to_ref(image_name, cache_registry, cache_tag_branch),
             dev_cache_from: dev_cache_from.join("\n"),
-            dev_cache_to: cache_to_ref("#{image_name}-dev", registry, "dev-#{cache_tag_branch}")
+            dev_cache_to: cache_to_ref("#{image_name}-dev", cache_registry, "dev-#{cache_tag_branch}")
           }
         end
       end
@@ -120,6 +121,7 @@ def merge_matrix(&)
         {
           version: version,
           primary_target: image_name,
+          registry: Util::REGISTRY,
           primary_tags: TagGenerator.primary_tags(image_name, values).join(' '),
           dev_tags: TagGenerator.dev_tags(image_name, values).join(' ')
         }
@@ -143,8 +145,4 @@ end
 def current_branch
   branch = ENV['GITHUB_REF'] || "refs/heads/#{Git.open(Dir.getwd).current_branch}"
   branch.gsub('refs/heads/', '')
-end
-
-def ghcr_registry
-  Util::GLOBAL_DEFAULTS.fetch('defaults').fetch('ghcr_registry')
 end

--- a/ruby/template/docker-bake.hcl.erb
+++ b/ruby/template/docker-bake.hcl.erb
@@ -18,10 +18,10 @@ target "<%= image_name %>" {
   context = "${PWD}/<%= image_name %>/<%= version %>"
   platforms = <%= platforms %>
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>",
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:<%= version %>"
+    "type=registry,ref=<%= registry %>/<%= image_name %>:cache-<%= version %>",
+    "type=registry,ref=<%= registry %>/<%= image_name %>:<%= version %>"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-<%= version %>,mode=max"]
+  cache-to = ["type=registry,ref=<%= registry %>/<%= image_name %>:cache-<%= version %>,mode=max"]
 }
 
 target "<%= image_name %>-dev" {
@@ -29,8 +29,8 @@ target "<%= image_name %>-dev" {
   inherits = ["<%= image_name %>"]
   tags = <%= docker_dev_tags %>
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>",
-    "type=registry,ref=ghcr.io/djbender/<%= image_name %>:dev-<%= version %>"
+    "type=registry,ref=<%= registry %>/<%= image_name %>:cache-dev-<%= version %>",
+    "type=registry,ref=<%= registry %>/<%= image_name %>:dev-<%= version %>"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/<%= image_name %>:cache-dev-<%= version %>,mode=max"]
+  cache-to = ["type=registry,ref=<%= registry %>/<%= image_name %>:cache-dev-<%= version %>,mode=max"]
 }

--- a/spec/image_generator_spec.rb
+++ b/spec/image_generator_spec.rb
@@ -1,0 +1,107 @@
+require 'tmpdir'
+require 'fileutils'
+require_relative '../lib/util'
+require_relative '../lib/image_generator'
+require_relative '../lib/template'
+require_relative '../lib/metadata'
+require_relative '../lib/generation_message'
+
+RSpec.describe ImageGenerator do
+  describe '#generate' do
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:template_dir) { File.join(tmpdir, 'test', 'template') }
+
+    before do
+      FileUtils.mkdir_p(template_dir)
+
+      # Create minimal Dockerfile template
+      File.write(File.join(template_dir, 'Dockerfile.erb'), <<~ERB)
+        FROM <%= base_image %>
+      ERB
+
+      # Create minimal docker-bake.hcl template
+      File.write(File.join(template_dir, 'docker-bake.hcl.erb'), <<~ERB)
+        target "<%= image_name %>" {
+          tags = ["<%= registry %>/<%= image_name %>:<%= version %>"]
+        }
+      ERB
+
+      # Stub Util methods to use tmpdir
+      allow(Util).to receive(:build_template_dir).with('test').and_return(File.join(tmpdir, 'test', 'template'))
+      allow(Util).to receive(:build_output_path) { |*parts| File.join(tmpdir, *parts) }
+
+      # Prevent orphan cleanup from prompting for input
+      allow($stdin).to receive(:tty?).and_return(false)
+
+      # Silence generator output
+      allow($stdout).to receive(:write)
+
+      # Use temp file for .generated.yml tracking
+      ImageGenerator.generated_file = File.join(tmpdir, '.generated.yml')
+    end
+
+    after do
+      FileUtils.rm_rf(tmpdir)
+      ImageGenerator.generated_file = nil
+    end
+
+    it 'interpolates %{registry} in base_image' do
+      details = {
+        'versions' => {
+          '1.0' => {
+            'base_image' => '%{registry}/core:noble'
+          }
+        }
+      }
+
+      generator = described_class.new(
+        image_name: 'test',
+        details: details,
+        task_name: 'generate:test'
+      )
+
+      # Capture stdout to suppress generation messages
+      expect { generator.generate }.to output(/Generating test Dockerfiles/).to_stdout
+
+      dockerfile = File.read(File.join(tmpdir, 'test', '1.0', 'Dockerfile'))
+      expect(dockerfile).to include('FROM ghcr.io/djbender/core:noble')
+    end
+
+    it 'passes registry to templates for ERB interpolation' do
+      details = {
+        'versions' => {
+          '2.0' => {}
+        }
+      }
+
+      generator = described_class.new(
+        image_name: 'test',
+        details: details,
+        task_name: 'generate:test'
+      )
+
+      expect { generator.generate }.to output(/Generating test Dockerfiles/).to_stdout
+
+      bake_file = File.read(File.join(tmpdir, 'test', '2.0', 'docker-bake.hcl'))
+      expect(bake_file).to include('tags = ["ghcr.io/djbender/test:2.0"]')
+    end
+
+    it 'raises helpful error for unknown placeholders' do
+      details = {
+        'versions' => {
+          '1.0' => {
+            'bad_field' => '%{unknown_placeholder}'
+          }
+        }
+      }
+
+      generator = described_class.new(
+        image_name: 'test',
+        details: details,
+        task_name: 'generate:test'
+      )
+
+      expect { generator.generate }.to raise_error(KeyError, /Unknown placeholder.*test.*bad_field.*unknown_placeholder/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Single source of truth for `ghcr.io/djbender` registry path in `manifest.yml`
- Removes duplication across TagGenerator, ci.rake, workflow, and templates
- Uses `%{registry}` placeholder in manifest `base_image` fields, interpolated at generation time

## Changes
- Add `registry` to manifest.yml globals
- Add `Util::REGISTRY` constant reading from manifest
- Update TagGenerator to use `Util::REGISTRY`
- Update docker-bake.hcl.erb templates to use `<%= registry %>`
- Update ci.rake to use `Util::REGISTRY`, add registry to matrix output
- Update workflow to use `matrix.registry`, hardcode `ghcr.io` for login-action
- Add `interpolate_registry` to ImageGenerator with helpful KeyError messages
- Make `ImageGenerator.generated_file` configurable for testing
- Add spec coverage for interpolation logic

Closes #250