### PR TITLE
Add copyright notice for Derek Bender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Node 23
 
 ### Changed
+- Add Derek Bender copyright to LICENSE alongside original Bridge copyright
 - Centralize cache config: `CacheRef` module builds cache ref strings, `HclFormatter` handles HCL list formatting for all array values in bake templates (#251)
 - Add `rubocop-rspec`, exclude `bin/` from rubocop
 - Centralize registry config: `ghcr.io/djbender` now defined once in `manifest.yml` globals (#250)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2022 Bridge
+Copyright (c) 2024 Derek Bender
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Add Derek Bender (c) 2024 to LICENSE alongside original Bridge copyright. This fork has been independently maintained since April 2024.