### PR TITLE
Cleanup docs site, reformat CHANGELOG

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,9 +9,11 @@ on:
       - 'CHANGELOG.md'
       - 'Parkfile'
       - 'bin/static-build'
-      - 'site/site_manifest.rb'
       - 'lib/manifest_loader.rb'
       - 'lib/tag_generator.rb'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '.ruby-version'
   workflow_dispatch: {}
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,53 +1,43 @@
 # Changelog
 
-## Unreleased
-
-### Added
+## 2026-02-10
 - GitHub Pages documentation site with Sinatra + Parklife static build
 - `lib/manifest_loader.rb` - shared manifest loading independent of Rake
 - `lib/site_manifest.rb` - manifest data layer for the documentation site
 - `deploy-docs.yml` workflow for automatic GitHub Pages deployment
-
-### Changed
 - `SiteManifest`: use `.except('globals')` instead of destructive `.delete`
 - `SiteManifest::Version`: accept image type name directly, remove `guess_image_name`
 - Remove unused pass-through helpers from site app
 - `deploy-docs.yml`: fix paths filter (remove redundant entry, add Gemfile/Gemfile.lock/.ruby-version)
 - `bin/static-build`: use `cp -R site/public/.` to avoid glob expansion edge case
 - Add SRI hash to Pico CSS CDN link
-
-### Fixed
 - Update core/README.md: add noble tags, remove stale slim tags
 - Update ruby/README.md: add all current versions/tags (2.4-4.0), fix patch versions and distro suffixes
-
-### Added
-- RSpec and RuboCop run in CI workflow
-- SimpleCov with branch coverage for RSpec tests
-- Native ARM64 builds using `ubuntu-24.04-arm` runners - significantly faster than QEMU emulation (ruby builds drop from ~40min to ~10min)
-- `lib/tag_generator.rb` - centralized tag generation for all image types
-- Merge jobs to create multi-arch manifests after platform-specific builds
-- `{major}-dev` tag for Ruby images (e.g., `ruby:3.3-dev`) - now matches Node pattern
-- CI gate job for stable branch protection check
-- Ruby 4.0 support (4.0.1)
-- Node 25 support
-- Orphan directory cleanup during generation - prompts before removing directories no longer in manifest (auto-confirms in non-TTY/CI environments)
-- `.generated.yml` tracks generated directories for cleanup detection
-
-### Removed
-- Node 8, 10, 12, 14 (NodeSource GPG key no longer available for old repos)
-- Node 21
-- Node 23
-
-### Changed
 - Add Derek Bender copyright to LICENSE alongside original Bridge copyright
 - Centralize cache config: `CacheRef` module builds cache ref strings, `HclFormatter` handles HCL list formatting for all array values in bake templates (#251)
 - Add `rubocop-rspec`, exclude `bin/` from rubocop
+
+## 2026-02-04
+- SimpleCov with branch coverage for RSpec tests
 - Centralize registry config: `ghcr.io/djbender` now defined once in `manifest.yml` globals (#250)
 - Centralize `platforms` config in `manifest.yml` globals (previously hardcoded in templates)
+- Native ARM64 builds using `ubuntu-24.04-arm` runners - significantly faster than QEMU emulation (ruby builds drop from ~40min to ~10min)
+- Drop Node 8, 10, 12, 14 (NodeSource GPG key no longer available for old repos)
 - Node 25: 25.3.0 → 25.6.0
+- Orphan directory cleanup during generation - prompts before removing directories no longer in manifest (auto-confirms in non-TTY/CI environments)
+- `.generated.yml` tracks generated directories for cleanup detection
+- Add native architecture build instructions to README
+
+## 2026-02-03
+- CI gate job for stable branch protection check
+- Ruby 4.0 support (4.0.1)
+- `{major}-dev` tag for Ruby images (e.g., `ruby:3.3-dev`) - now matches Node pattern
+- Merge jobs to create multi-arch manifests after platform-specific builds
+- RSpec and RuboCop run in CI workflow
 - dependabot.yml updated for node version changes
 - .rubocop.yml migrated from `require` to `plugins` syntax
 - Use `YAML.safe_load_file` for security in ImageGenerator
-
-### Removed (code)
-- Unused `copy_non_template_files` method from ImageGenerator
+- Remove unused `copy_non_template_files` method from ImageGenerator
+- Drop Node 21, 23
+- Improve "How to build" section formatting in README
+- Remove deprecated `docker buildx install` step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 - `lib/site_manifest.rb` - manifest data layer for the documentation site
 - `deploy-docs.yml` workflow for automatic GitHub Pages deployment
 
+### Changed
+- `SiteManifest`: use `.except('globals')` instead of destructive `.delete`
+- `SiteManifest::Version`: accept image type name directly, remove `guess_image_name`
+- Remove unused pass-through helpers from site app
+- `deploy-docs.yml`: fix paths filter (remove redundant entry, add Gemfile/Gemfile.lock/.ruby-version)
+- `bin/static-build`: use `cp -R site/public/.` to avoid glob expansion edge case
+- Add SRI hash to Pico CSS CDN link
+
 ### Fixed
 - Update core/README.md: add noble tags, remove stale slim tags
 - Update ruby/README.md: add all current versions/tags (2.4-4.0), fix patch versions and distro suffixes

--- a/bin/static-build
+++ b/bin/static-build
@@ -2,5 +2,5 @@
 set -eu
 export APP_ENV=production
 bundle exec parklife build "$@"
-[ -d site/public ] && cp -R site/public/* build
+[ -d site/public ] && cp -R site/public/. build/
 find build -type f | sort

--- a/site/app.rb
+++ b/site/app.rb
@@ -7,20 +7,8 @@ set :views, File.join(__dir__, 'views')
 set :public_folder, File.join(__dir__, 'public')
 
 helpers do
-  def manifest
-    SiteManifest
-  end
-
   def registry
     SiteManifest.registry
-  end
-
-  def primary_tags(version)
-    version.primary_tags
-  end
-
-  def dev_tags(version)
-    version.dev_tags
   end
 
   def pull_command(image_name, tag = nil)

--- a/site/site_manifest.rb
+++ b/site/site_manifest.rb
@@ -27,7 +27,7 @@ module SiteManifest
         attrs = defaults.merge(version_values || {})
         attrs['version'] = version_key.to_s
         attrs = interpolate_registry(attrs)
-        ImageType::Version.new(version_key.to_s, attrs)
+        ImageType::Version.new(version_key.to_s, attrs, name)
       end
     end
 
@@ -36,11 +36,7 @@ module SiteManifest
     end
 
     def manifest
-      @manifest ||= begin
-        m = ManifestLoader.load
-        m.delete('globals')
-        m
-      end
+      @manifest ||= ManifestLoader.load.except('globals')
     end
 
     def globals
@@ -72,11 +68,12 @@ module SiteManifest
 
     # Plain class instead of Struct to avoid overriding Struct#values
     class Version
-      attr_reader :key, :attrs
+      attr_reader :key, :attrs, :image_type_name
 
-      def initialize(key, attrs)
+      def initialize(key, attrs, image_type_name)
         @key = key
         @attrs = attrs
+        @image_type_name = image_type_name
       end
 
       def primary_tags
@@ -85,22 +82,6 @@ module SiteManifest
 
       def dev_tags
         TagGenerator.dev_tags(image_type_name, attrs)
-      end
-
-      private
-
-      def image_type_name
-        attrs['image_name'] || attrs[:image_name] || guess_image_name
-      end
-
-      def guess_image_name
-        if attrs.key?('ruby_version') || attrs.key?(:ruby_version)
-          'ruby'
-        elsif attrs.key?('node_version') || attrs.key?(:node_version)
-          'node'
-        else
-          'core'
-        end
       end
     end
   end

--- a/site/views/_image_table.erb
+++ b/site/views/_image_table.erb
@@ -17,16 +17,16 @@
         <td><code class="pull-cmd"><%= pull_command(image_type.name, version.key) %></code></td>
         <td>
           <details>
-            <summary><%= primary_tags(version).size + dev_tags(version).size %> tags</summary>
+            <summary><%= version.primary_tags.size + version.dev_tags.size %> tags</summary>
             <strong>Primary:</strong>
             <ul>
-              <% primary_tags(version).each do |tag| %>
+              <% version.primary_tags.each do |tag| %>
                 <li><code><%= tag %></code></li>
               <% end %>
             </ul>
             <strong>Dev:</strong>
             <ul>
-              <% dev_tags(version).each do |tag| %>
+              <% version.dev_tags.each do |tag| %>
                 <li><code><%= tag %></code></li>
               <% end %>
             </ul>

--- a/site/views/layout.erb
+++ b/site/views/layout.erb
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title><%= @title ? "#{@title} - Docker Base Images" : 'Docker Base Images' %></title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" integrity="sha384-L1dWfspMTHU/ApYnFiMz2QID/PlP1xCW9visvBdbEkOLkSSWsP6ZJWhPw6apiXxU" crossorigin="anonymous">
   <link rel="stylesheet" href="/css/custom.css">
 </head>
 <body>

--- a/spec/site_manifest_spec.rb
+++ b/spec/site_manifest_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe SiteManifest do
     let(:image_type) { described_class.new('ruby', versions) }
     let(:versions) do
       [
-        SiteManifest::ImageType::Version.new('3.3', { 'version' => '3.3' }),
-        SiteManifest::ImageType::Version.new('4.0', { 'version' => '4.0', 'latest' => true })
+        SiteManifest::ImageType::Version.new('3.3', { 'version' => '3.3' }, 'ruby'),
+        SiteManifest::ImageType::Version.new('4.0', { 'version' => '4.0', 'latest' => true }, 'ruby')
       ]
     end
 
@@ -87,8 +87,8 @@ RSpec.describe SiteManifest do
 
       it 'falls back to last version when none marked latest' do
         no_latest = [
-          SiteManifest::ImageType::Version.new('3.3', { 'version' => '3.3' }),
-          SiteManifest::ImageType::Version.new('3.4', { 'version' => '3.4' })
+          SiteManifest::ImageType::Version.new('3.3', { 'version' => '3.3' }, 'ruby'),
+          SiteManifest::ImageType::Version.new('3.4', { 'version' => '3.4' }, 'ruby')
         ]
         type = described_class.new('ruby', no_latest)
 
@@ -114,7 +114,7 @@ RSpec.describe SiteManifest do
                               'ruby_version' => '3.3.0',
                               'ruby_major' => '3.3',
                               'distribution_code_name' => 'noble'
-                            })
+                            }, 'ruby')
       end
 
       it 'generates primary tags via TagGenerator' do
@@ -133,10 +133,10 @@ RSpec.describe SiteManifest do
                               'node_version' => '22.1.0',
                               'node_major' => '22',
                               'distribution_code_name' => 'noble'
-                            })
+                            }, 'node')
       end
 
-      it 'detects image type as node' do
+      it 'generates primary tags via TagGenerator' do
         expect(version.primary_tags).to include("#{registry}/node:22.1.0")
       end
     end
@@ -146,10 +146,10 @@ RSpec.describe SiteManifest do
         described_class.new('noble', {
                               'version' => 'noble',
                               'distribution_code_name' => 'noble'
-                            })
+                            }, 'core')
       end
 
-      it 'detects image type as core' do
+      it 'generates primary tags via TagGenerator' do
         expect(version.primary_tags).to include("#{registry}/core:noble")
       end
 


### PR DESCRIPTION
## Summary
- Rewrite CHANGELOG.md from Keep-a-Changelog categories to flat date-based sections (2026-02-10, 2026-02-04, 2026-02-03)
- Add CLAUDE.md with project-specific instructions
- Docs site cleanup: remove `guess_image_name`, fix paths filter, add SRI