### PR TITLE
Fix docs site links missing base path prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2026-02-13
+- Fix docs site links missing GitHub Pages base path prefix (`/docker-base-images`)
+
 ## 2026-02-12
 - `bin/check-versions` — unified version checker for Ruby + Node using Strategy pattern
 - Split `VersionChecker`, `RubyChecker`, `NodeChecker` into separate files under `lib/`

--- a/bin/static-build
+++ b/bin/static-build
@@ -1,6 +1,16 @@
 #!/usr/bin/env sh
 set -eu
 export APP_ENV=production
+
+# Extract --base value and expose it to the Sinatra app
+prev=""
+for arg in "$@"; do
+  case "$prev" in
+    --base) export BASE_PATH="$arg" ;;
+  esac
+  prev="$arg"
+done
+
 bundle exec parklife build "$@"
 [ -d site/public ] && cp -R site/public/. build/
 find build -type f | sort

--- a/site/app.rb
+++ b/site/app.rb
@@ -7,6 +7,14 @@ set :views, File.join(__dir__, 'views')
 set :public_folder, File.join(__dir__, 'public')
 
 helpers do
+  def base_path
+    ENV.fetch('BASE_PATH', '')
+  end
+
+  def url_for(path)
+    "#{base_path}#{path}"
+  end
+
   def registry
     SiteManifest.registry
   end

--- a/site/views/catalog.erb
+++ b/site/views/catalog.erb
@@ -3,7 +3,7 @@
 
 <% @image_types.each do |image_type| %>
   <section>
-    <h2><a href="/<%= image_type.name %>"><%= image_type.name.capitalize %></a></h2>
+    <h2><a href="<%= url_for("/#{image_type.name}") %>"><%= image_type.name.capitalize %></a></h2>
     <%= erb :_image_table, locals: { image_type: image_type } %>
   </section>
 <% end %>

--- a/site/views/home.erb
+++ b/site/views/home.erb
@@ -4,7 +4,7 @@
 <% @image_types.each do |image_type| %>
   <% latest = image_type.latest_version %>
   <article>
-    <header><h3><a href="/<%= image_type.name %>"><%= image_type.name.capitalize %></a></h3></header>
+    <header><h3><a href="<%= url_for("/#{image_type.name}") %>"><%= image_type.name.capitalize %></a></h3></header>
     <div class="image-card-row">
       <p><strong><%= image_type.versions.size %></strong> versions available</p>
       <% if latest %>

--- a/site/views/layout.erb
+++ b/site/views/layout.erb
@@ -5,22 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title><%= @title ? "#{@title} - Docker Base Images" : 'Docker Base Images' %></title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" integrity="sha384-L1dWfspMTHU/ApYnFiMz2QID/PlP1xCW9visvBdbEkOLkSSWsP6ZJWhPw6apiXxU" crossorigin="anonymous">
-  <link rel="stylesheet" href="/css/custom.css">
+  <link rel="stylesheet" href="<%= url_for('/css/custom.css') %>">
 </head>
 <body>
   <header class="container">
     <nav>
       <ul>
-        <li><strong><a href="/">Docker Base Images</a></strong></li>
+        <li><strong><a href="<%= url_for('/') %>">Docker Base Images</a></strong></li>
       </ul>
       <ul>
-        <li><a href="/catalog" class="<%= active_class('/catalog') %>">Catalog</a></li>
-        <li><a href="/core" class="<%= active_class('/core') %>">Core</a></li>
-        <li><a href="/ruby" class="<%= active_class('/ruby') %>">Ruby</a></li>
-        <li><a href="/node" class="<%= active_class('/node') %>">Node</a></li>
-        <li><a href="/getting-started" class="<%= active_class('/getting-started') %>">Getting Started</a></li>
-        <li><a href="/architecture" class="<%= active_class('/architecture') %>">Architecture</a></li>
-        <li><a href="/changelog" class="<%= active_class('/changelog') %>">Changelog</a></li>
+        <li><a href="<%= url_for('/catalog') %>" class="<%= active_class('/catalog') %>">Catalog</a></li>
+        <li><a href="<%= url_for('/core') %>" class="<%= active_class('/core') %>">Core</a></li>
+        <li><a href="<%= url_for('/ruby') %>" class="<%= active_class('/ruby') %>">Ruby</a></li>
+        <li><a href="<%= url_for('/node') %>" class="<%= active_class('/node') %>">Node</a></li>
+        <li><a href="<%= url_for('/getting-started') %>" class="<%= active_class('/getting-started') %>">Getting Started</a></li>
+        <li><a href="<%= url_for('/architecture') %>" class="<%= active_class('/architecture') %>">Architecture</a></li>
+        <li><a href="<%= url_for('/changelog') %>" class="<%= active_class('/changelog') %>">Changelog</a></li>
         <li><a href="#" id="theme-toggle" role="button" class="outline contrast theme-toggle"></a></li>
       </ul>
     </nav>


### PR DESCRIPTION
## Summary
- Links on deployed docs site pointed to `https://djbender.github.io/catalog` instead of `https://djbender.github.io/docker-base-images/catalog`
- `bin/static-build` now extracts `--base` value into `BASE_PATH` env var
- Added `url_for` helper to Sinatra app that prepends base path to all internal links
- Updated all ERB views to use `url_for()` for hrefs