### PR TITLE
Remove stale dependabot entries for retired node versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,46 +52,6 @@ updates:
       - notification-only
 
   - package-ecosystem: docker
-    directory: node/8
-    schedule:
-      interval: daily
-    labels:
-      - dependencies
-      - do-not-merge
-      - docker
-      - notification-only
-
-  - package-ecosystem: docker
-    directory: node/10
-    schedule:
-      interval: daily
-    labels:
-      - dependencies
-      - do-not-merge
-      - docker
-      - notification-only
-
-  - package-ecosystem: docker
-    directory: node/12
-    schedule:
-      interval: daily
-    labels:
-      - dependencies
-      - do-not-merge
-      - docker
-      - notification-only
-
-  - package-ecosystem: docker
-    directory: node/14
-    schedule:
-      interval: daily
-    labels:
-      - dependencies
-      - do-not-merge
-      - docker
-      - notification-only
-
-  - package-ecosystem: docker
     directory: node/16
     schedule:
       interval: daily

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2026-03-05
+- Remove stale dependabot entries for retired node versions (8, 10, 12, 14)
+
 ## 2026-02-13
 - Fix docs site links missing GitHub Pages base path prefix (`/docker-base-images`)
 


### PR DESCRIPTION
## Summary
- Remove dependabot docker ecosystem entries for node 8, 10, 12, 14 — directories no longer exist