### PR TITLE
Fix dev cache fallback ref to match image tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2026-03-10
-- Fix dev cache tag ordering: `dev-<version>` → `<version>-dev` to match actual pushed tags
+- Fix dev cache fallback ref: `dev-<version>` → `<version>-dev` to match actual image tags
 - Disable `cache-to` in local build tasks to avoid 403 errors pushing to GHCR
 
 ## 2026-03-05

--- a/core/bionic/docker-bake.hcl
+++ b/core/bionic/docker-bake.hcl
@@ -37,8 +37,8 @@ target "core-dev" {
   inherits = ["core"]
   tags = ["ghcr.io/djbender/core:bionic-dev"]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/core:cache-bionic-dev",
+    "type=registry,ref=ghcr.io/djbender/core:cache-dev-bionic",
     "type=registry,ref=ghcr.io/djbender/core:bionic-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-bionic-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-dev-bionic,mode=max"]
 }

--- a/core/jammy/docker-bake.hcl
+++ b/core/jammy/docker-bake.hcl
@@ -37,8 +37,8 @@ target "core-dev" {
   inherits = ["core"]
   tags = ["ghcr.io/djbender/core:jammy-dev"]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/core:cache-jammy-dev",
+    "type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy",
     "type=registry,ref=ghcr.io/djbender/core:jammy-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-jammy-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy,mode=max"]
 }

--- a/core/noble/docker-bake.hcl
+++ b/core/noble/docker-bake.hcl
@@ -43,8 +43,8 @@ target "core-dev" {
     "ghcr.io/djbender/core:noble-dev"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/core:cache-noble-dev",
+    "type=registry,ref=ghcr.io/djbender/core:cache-dev-noble",
     "type=registry,ref=ghcr.io/djbender/core:noble-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-noble-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-dev-noble,mode=max"]
 }

--- a/lib/metadata.rb
+++ b/lib/metadata.rb
@@ -51,11 +51,11 @@ class Metadata
   # Cache configuration for dev target
   def cache_from_dev
     reg = "#{registry}/#{image_name}"
-    [CacheRef.from(reg, "#{version}-dev"), CacheRef.fallback(reg, "#{version}-dev")]
+    [CacheRef.from(reg, "dev-#{version}"), CacheRef.fallback(reg, "#{version}-dev")]
   end
 
   def cache_to_dev
-    [CacheRef.to("#{registry}/#{image_name}", "#{version}-dev")]
+    [CacheRef.to("#{registry}/#{image_name}", "dev-#{version}")]
   end
 
   def branch_suffix

--- a/node/16/docker-bake.hcl
+++ b/node/16/docker-bake.hcl
@@ -47,8 +47,8 @@ target "node-dev" {
     "ghcr.io/djbender/node:16.20.2-dev-jammy"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-16-dev",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-16",
     "type=registry,ref=ghcr.io/djbender/node:16-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-16-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-16,mode=max"]
 }

--- a/node/18/docker-bake.hcl
+++ b/node/18/docker-bake.hcl
@@ -47,8 +47,8 @@ target "node-dev" {
     "ghcr.io/djbender/node:18.20.8-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-18-dev",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-18",
     "type=registry,ref=ghcr.io/djbender/node:18-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-18-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-18,mode=max"]
 }

--- a/node/20/docker-bake.hcl
+++ b/node/20/docker-bake.hcl
@@ -47,8 +47,8 @@ target "node-dev" {
     "ghcr.io/djbender/node:20.20.0-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-20-dev",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-20",
     "type=registry,ref=ghcr.io/djbender/node:20-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-20-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-20,mode=max"]
 }

--- a/node/22/docker-bake.hcl
+++ b/node/22/docker-bake.hcl
@@ -47,8 +47,8 @@ target "node-dev" {
     "ghcr.io/djbender/node:22.22.0-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-22-dev",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-22",
     "type=registry,ref=ghcr.io/djbender/node:22-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-22-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-22,mode=max"]
 }

--- a/node/24/docker-bake.hcl
+++ b/node/24/docker-bake.hcl
@@ -49,8 +49,8 @@ target "node-dev" {
     "ghcr.io/djbender/node:dev"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-24-dev",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-24",
     "type=registry,ref=ghcr.io/djbender/node:24-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-24-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-24,mode=max"]
 }

--- a/node/25/docker-bake.hcl
+++ b/node/25/docker-bake.hcl
@@ -47,8 +47,8 @@ target "node-dev" {
     "ghcr.io/djbender/node:25.6.1-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-25-dev",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-25",
     "type=registry,ref=ghcr.io/djbender/node:25-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-25-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-25,mode=max"]
 }

--- a/ruby/2.4/docker-bake.hcl
+++ b/ruby/2.4/docker-bake.hcl
@@ -47,8 +47,8 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:2.4.10-dev-bionic"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.4-dev",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.4",
     "type=registry,ref=ghcr.io/djbender/ruby:2.4-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.4-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.4,mode=max"]
 }

--- a/ruby/2.5/docker-bake.hcl
+++ b/ruby/2.5/docker-bake.hcl
@@ -47,8 +47,8 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:2.5.9-dev-bionic"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.5-dev",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.5",
     "type=registry,ref=ghcr.io/djbender/ruby:2.5-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.5-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.5,mode=max"]
 }

--- a/ruby/2.6/docker-bake.hcl
+++ b/ruby/2.6/docker-bake.hcl
@@ -47,8 +47,8 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:2.6.10-dev-bionic"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.6-dev",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.6",
     "type=registry,ref=ghcr.io/djbender/ruby:2.6-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.6-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.6,mode=max"]
 }

--- a/ruby/2.7/docker-bake.hcl
+++ b/ruby/2.7/docker-bake.hcl
@@ -47,8 +47,8 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:2.7.8-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.7-dev",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.7",
     "type=registry,ref=ghcr.io/djbender/ruby:2.7-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.7-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.7,mode=max"]
 }

--- a/ruby/3.0/docker-bake.hcl
+++ b/ruby/3.0/docker-bake.hcl
@@ -47,8 +47,8 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:3.0.7-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.0-dev",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.0",
     "type=registry,ref=ghcr.io/djbender/ruby:3.0-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.0-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.0,mode=max"]
 }

--- a/ruby/3.1/docker-bake.hcl
+++ b/ruby/3.1/docker-bake.hcl
@@ -47,8 +47,8 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:3.1.7-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.1-dev",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.1",
     "type=registry,ref=ghcr.io/djbender/ruby:3.1-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.1-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.1,mode=max"]
 }

--- a/ruby/3.2/docker-bake.hcl
+++ b/ruby/3.2/docker-bake.hcl
@@ -47,8 +47,8 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:3.2.10-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.2-dev",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.2",
     "type=registry,ref=ghcr.io/djbender/ruby:3.2-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.2-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.2,mode=max"]
 }

--- a/ruby/3.3/docker-bake.hcl
+++ b/ruby/3.3/docker-bake.hcl
@@ -47,8 +47,8 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:3.3.10-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.3-dev",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.3",
     "type=registry,ref=ghcr.io/djbender/ruby:3.3-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.3-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.3,mode=max"]
 }

--- a/ruby/3.4/docker-bake.hcl
+++ b/ruby/3.4/docker-bake.hcl
@@ -47,8 +47,8 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:3.4.8-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.4-dev",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.4",
     "type=registry,ref=ghcr.io/djbender/ruby:3.4-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.4-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.4,mode=max"]
 }

--- a/ruby/4.0/docker-bake.hcl
+++ b/ruby/4.0/docker-bake.hcl
@@ -49,8 +49,8 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:dev"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-4.0-dev",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-4.0",
     "type=registry,ref=ghcr.io/djbender/ruby:4.0-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-4.0-dev,mode=max"]
+  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-4.0,mode=max"]
 }

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Metadata do
   describe '#cache_from_dev' do
     it 'returns array with dev cache ref and dev image ref' do
       expect(metadata.cache_from_dev).to eq [
-        'type=registry,ref=ghcr.io/djbender/core:cache-jammy-dev',
+        'type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy',
         'type=registry,ref=ghcr.io/djbender/core:jammy-dev'
       ]
     end
@@ -118,7 +118,7 @@ RSpec.describe Metadata do
   describe '#cache_to_dev' do
     it 'returns single-element array with dev mode=max' do
       expect(metadata.cache_to_dev).to eq [
-        'type=registry,ref=ghcr.io/djbender/core:cache-jammy-dev,mode=max'
+        'type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy,mode=max'
       ]
     end
   end


### PR DESCRIPTION
## Summary
- Keep `dev-` prefix for dedicated cache tags (`cache-dev-jammy`) — these are internal to buildx
- Fix fallback `cache-from` ref: `dev-<version>` → `<version>-dev` to match actual image tags (e.g. `jammy-dev`)
- Regenerate all `docker-bake.hcl` files