### PR TITLE
Leverage CI per-arch cache in local builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## 2026-03-10
-- Fix dev cache fallback ref: `dev-<version>` → `<version>-dev` to match actual image tags
-- Disable `cache-to` in local build tasks to avoid 403 errors pushing to GHCR
+- Local builds now pull CI's per-arch `mode=max` cache via `ARCH` HCL variable
+- Remove `cache-to` from bake files (CI overrides via `--set`, local builds don't push)
+- Dynamic arch detection in `build.rake` (overridable via `ARCH=amd64`)
 
 ## 2026-03-05
 - Remove stale dependabot entries for retired node versions (8, 10, 12, 14)

--- a/core/bionic/docker-bake.hcl
+++ b/core/bionic/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -26,10 +27,9 @@ target "core" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/core:cache-bionic",
+    "type=registry,ref=ghcr.io/djbender/core:cache-bionic-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/core:bionic"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-bionic,mode=max"]
 }
 
 target "core-dev" {
@@ -37,8 +37,7 @@ target "core-dev" {
   inherits = ["core"]
   tags = ["ghcr.io/djbender/core:bionic-dev"]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/core:cache-dev-bionic",
+    "type=registry,ref=ghcr.io/djbender/core:cache-dev-bionic-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/core:bionic-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-dev-bionic,mode=max"]
 }

--- a/core/jammy/docker-bake.hcl
+++ b/core/jammy/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -26,10 +27,9 @@ target "core" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/core:cache-jammy",
+    "type=registry,ref=ghcr.io/djbender/core:cache-jammy-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/core:jammy"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-jammy,mode=max"]
 }
 
 target "core-dev" {
@@ -37,8 +37,7 @@ target "core-dev" {
   inherits = ["core"]
   tags = ["ghcr.io/djbender/core:jammy-dev"]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy",
+    "type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/core:jammy-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy,mode=max"]
 }

--- a/core/noble/docker-bake.hcl
+++ b/core/noble/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -29,10 +30,9 @@ target "core" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/core:cache-noble",
+    "type=registry,ref=ghcr.io/djbender/core:cache-noble-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/core:noble"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-noble,mode=max"]
 }
 
 target "core-dev" {
@@ -43,8 +43,7 @@ target "core-dev" {
     "ghcr.io/djbender/core:noble-dev"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/core:cache-dev-noble",
+    "type=registry,ref=ghcr.io/djbender/core:cache-dev-noble-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/core:noble-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/core:cache-dev-noble,mode=max"]
 }

--- a/core/template/docker-bake.hcl.erb
+++ b/core/template/docker-bake.hcl.erb
@@ -3,6 +3,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -18,7 +19,6 @@ target "<%= image_name %>" {
   context = "${PWD}/<%= image_name %>/<%= version %>"
   platforms = <%= hcl_list(platforms) %>
   cache-from = <%= hcl_list(cache_from) %>
-  cache-to = <%= hcl_list(cache_to) %>
 }
 
 target "<%= image_name %>-dev" {
@@ -26,5 +26,4 @@ target "<%= image_name %>-dev" {
   inherits = ["<%= image_name %>"]
   tags = <%= hcl_list(docker_dev_tags) %>
   cache-from = <%= hcl_list(cache_from_dev) %>
-  cache-to = <%= hcl_list(cache_to_dev) %>
 }

--- a/lib/metadata.rb
+++ b/lib/metadata.rb
@@ -38,24 +38,17 @@ class Metadata
     TagGenerator.dev_tags(image_name, @values)
   end
 
-  # Cache configuration for primary target
+  # Cache configuration for primary target (bake files are local-only;
+  # CI overrides cache-from via --set with per-arch tags)
   def cache_from
     reg = "#{registry}/#{image_name}"
-    [CacheRef.from(reg, version), CacheRef.fallback(reg, version)]
-  end
-
-  def cache_to
-    [CacheRef.to("#{registry}/#{image_name}", version)]
+    [CacheRef.from(reg, "#{version}-${ARCH}"), CacheRef.fallback(reg, version)]
   end
 
   # Cache configuration for dev target
   def cache_from_dev
     reg = "#{registry}/#{image_name}"
-    [CacheRef.from(reg, "dev-#{version}"), CacheRef.fallback(reg, "#{version}-dev")]
-  end
-
-  def cache_to_dev
-    [CacheRef.to("#{registry}/#{image_name}", "dev-#{version}")]
+    [CacheRef.from(reg, "dev-#{version}-${ARCH}"), CacheRef.fallback(reg, "#{version}-dev")]
   end
 
   def branch_suffix

--- a/node/16/docker-bake.hcl
+++ b/node/16/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "node" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-16",
+    "type=registry,ref=ghcr.io/djbender/node:cache-16-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:16"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-16,mode=max"]
 }
 
 target "node-dev" {
@@ -47,8 +47,7 @@ target "node-dev" {
     "ghcr.io/djbender/node:16.20.2-dev-jammy"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-dev-16",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-16-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:16-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-16,mode=max"]
 }

--- a/node/18/docker-bake.hcl
+++ b/node/18/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "node" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-18",
+    "type=registry,ref=ghcr.io/djbender/node:cache-18-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:18"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-18,mode=max"]
 }
 
 target "node-dev" {
@@ -47,8 +47,7 @@ target "node-dev" {
     "ghcr.io/djbender/node:18.20.8-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-dev-18",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-18-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:18-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-18,mode=max"]
 }

--- a/node/20/docker-bake.hcl
+++ b/node/20/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "node" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-20",
+    "type=registry,ref=ghcr.io/djbender/node:cache-20-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:20"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-20,mode=max"]
 }
 
 target "node-dev" {
@@ -47,8 +47,7 @@ target "node-dev" {
     "ghcr.io/djbender/node:20.20.0-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-dev-20",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-20-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:20-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-20,mode=max"]
 }

--- a/node/22/docker-bake.hcl
+++ b/node/22/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "node" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-22",
+    "type=registry,ref=ghcr.io/djbender/node:cache-22-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:22"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-22,mode=max"]
 }
 
 target "node-dev" {
@@ -47,8 +47,7 @@ target "node-dev" {
     "ghcr.io/djbender/node:22.22.0-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-dev-22",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-22-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:22-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-22,mode=max"]
 }

--- a/node/24/docker-bake.hcl
+++ b/node/24/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -32,10 +33,9 @@ target "node" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-24",
+    "type=registry,ref=ghcr.io/djbender/node:cache-24-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:24"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-24,mode=max"]
 }
 
 target "node-dev" {
@@ -49,8 +49,7 @@ target "node-dev" {
     "ghcr.io/djbender/node:dev"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-dev-24",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-24-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:24-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-24,mode=max"]
 }

--- a/node/25/docker-bake.hcl
+++ b/node/25/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "node" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-25",
+    "type=registry,ref=ghcr.io/djbender/node:cache-25-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:25"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-25,mode=max"]
 }
 
 target "node-dev" {
@@ -47,8 +47,7 @@ target "node-dev" {
     "ghcr.io/djbender/node:25.6.1-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/node:cache-dev-25",
+    "type=registry,ref=ghcr.io/djbender/node:cache-dev-25-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/node:25-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/node:cache-dev-25,mode=max"]
 }

--- a/node/template/docker-bake.hcl.erb
+++ b/node/template/docker-bake.hcl.erb
@@ -3,6 +3,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -18,7 +19,6 @@ target "<%= image_name %>" {
   context = "${PWD}/<%= image_name %>/<%= version %>"
   platforms = <%= hcl_list(platforms) %>
   cache-from = <%= hcl_list(cache_from) %>
-  cache-to = <%= hcl_list(cache_to) %>
 }
 
 target "<%= image_name %>-dev" {
@@ -26,5 +26,4 @@ target "<%= image_name %>-dev" {
   inherits = ["<%= image_name %>"]
   tags = <%= hcl_list(docker_dev_tags) %>
   cache-from = <%= hcl_list(cache_from_dev) %>
-  cache-to = <%= hcl_list(cache_to_dev) %>
 }

--- a/rakelib/build.rake
+++ b/rakelib/build.rake
@@ -59,8 +59,13 @@ namespace :build do
 end
 
 module Build
+  def self.arch
+    ENV.fetch('ARCH') { RUBY_PLATFORM.include?('arm') ? 'arm64' : 'amd64' }
+  end
+
   def self.command(bake_file)
-    %W[docker buildx bake --file #{bake_file} --set *.platform=linux/arm64 --set *.cache-to= --load]
+    ENV['ARCH'] = arch
+    %W[docker buildx bake --file #{bake_file} --set *.platform=linux/#{arch} --load]
   end
 
   def self.matrix(&)

--- a/ruby/2.4/docker-bake.hcl
+++ b/ruby/2.4/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "ruby" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.4",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.4-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:2.4"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.4,mode=max"]
 }
 
 target "ruby-dev" {
@@ -47,8 +47,7 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:2.4.10-dev-bionic"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.4",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.4-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:2.4-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.4,mode=max"]
 }

--- a/ruby/2.5/docker-bake.hcl
+++ b/ruby/2.5/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "ruby" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.5",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.5-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:2.5"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.5,mode=max"]
 }
 
 target "ruby-dev" {
@@ -47,8 +47,7 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:2.5.9-dev-bionic"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.5",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.5-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:2.5-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.5,mode=max"]
 }

--- a/ruby/2.6/docker-bake.hcl
+++ b/ruby/2.6/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "ruby" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.6",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.6-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:2.6"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.6,mode=max"]
 }
 
 target "ruby-dev" {
@@ -47,8 +47,7 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:2.6.10-dev-bionic"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.6",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.6-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:2.6-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.6,mode=max"]
 }

--- a/ruby/2.7/docker-bake.hcl
+++ b/ruby/2.7/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "ruby" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.7",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-2.7-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:2.7"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-2.7,mode=max"]
 }
 
 target "ruby-dev" {
@@ -47,8 +47,7 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:2.7.8-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.7",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.7-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:2.7-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-2.7,mode=max"]
 }

--- a/ruby/3.0/docker-bake.hcl
+++ b/ruby/3.0/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "ruby" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.0",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.0-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:3.0"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.0,mode=max"]
 }
 
 target "ruby-dev" {
@@ -47,8 +47,7 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:3.0.7-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.0",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.0-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:3.0-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.0,mode=max"]
 }

--- a/ruby/3.1/docker-bake.hcl
+++ b/ruby/3.1/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "ruby" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.1",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.1-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:3.1"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.1,mode=max"]
 }
 
 target "ruby-dev" {
@@ -47,8 +47,7 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:3.1.7-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.1",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.1-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:3.1-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.1,mode=max"]
 }

--- a/ruby/3.2/docker-bake.hcl
+++ b/ruby/3.2/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "ruby" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.2",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.2-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:3.2"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.2,mode=max"]
 }
 
 target "ruby-dev" {
@@ -47,8 +47,7 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:3.2.10-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.2",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.2-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:3.2-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.2,mode=max"]
 }

--- a/ruby/3.3/docker-bake.hcl
+++ b/ruby/3.3/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "ruby" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.3",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.3-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:3.3"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.3,mode=max"]
 }
 
 target "ruby-dev" {
@@ -47,8 +47,7 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:3.3.10-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.3",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.3-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:3.3-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.3,mode=max"]
 }

--- a/ruby/3.4/docker-bake.hcl
+++ b/ruby/3.4/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -31,10 +32,9 @@ target "ruby" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.4",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-3.4-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:3.4"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-3.4,mode=max"]
 }
 
 target "ruby-dev" {
@@ -47,8 +47,7 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:3.4.8-dev-noble"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.4",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.4-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:3.4-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.4,mode=max"]
 }

--- a/ruby/4.0/docker-bake.hcl
+++ b/ruby/4.0/docker-bake.hcl
@@ -8,6 +8,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -32,10 +33,9 @@ target "ruby" {
     "linux/arm64"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-4.0",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-4.0-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:4.0"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-4.0,mode=max"]
 }
 
 target "ruby-dev" {
@@ -49,8 +49,7 @@ target "ruby-dev" {
     "ghcr.io/djbender/ruby:dev"
   ]
   cache-from = [
-    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-4.0",
+    "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-4.0-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/ruby:4.0-dev"
   ]
-  cache-to = ["type=registry,ref=ghcr.io/djbender/ruby:cache-dev-4.0,mode=max"]
 }

--- a/ruby/template/docker-bake.hcl.erb
+++ b/ruby/template/docker-bake.hcl.erb
@@ -3,6 +3,7 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
+variable "ARCH" {default="" }
 
 group "default" {
   targets = [
@@ -18,7 +19,6 @@ target "<%= image_name %>" {
   context = "${PWD}/<%= image_name %>/<%= version %>"
   platforms = <%= hcl_list(platforms) %>
   cache-from = <%= hcl_list(cache_from) %>
-  cache-to = <%= hcl_list(cache_to) %>
 }
 
 target "<%= image_name %>-dev" {
@@ -26,5 +26,4 @@ target "<%= image_name %>-dev" {
   inherits = ["<%= image_name %>"]
   tags = <%= hcl_list(docker_dev_tags) %>
   cache-from = <%= hcl_list(cache_from_dev) %>
-  cache-to = <%= hcl_list(cache_to_dev) %>
 }

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -90,35 +90,19 @@ RSpec.describe Metadata do
   end
 
   describe '#cache_from' do
-    it 'returns array with cache ref and image ref' do
+    it 'returns per-arch cache ref with image tag fallback' do
       expect(metadata.cache_from).to eq [
-        'type=registry,ref=ghcr.io/djbender/core:cache-jammy',
+        'type=registry,ref=ghcr.io/djbender/core:cache-jammy-${ARCH}',
         'type=registry,ref=ghcr.io/djbender/core:jammy'
       ]
     end
   end
 
-  describe '#cache_to' do
-    it 'returns single-element array with mode=max' do
-      expect(metadata.cache_to).to eq [
-        'type=registry,ref=ghcr.io/djbender/core:cache-jammy,mode=max'
-      ]
-    end
-  end
-
   describe '#cache_from_dev' do
-    it 'returns array with dev cache ref and dev image ref' do
+    it 'returns per-arch dev cache ref with image tag fallback' do
       expect(metadata.cache_from_dev).to eq [
-        'type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy',
+        'type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy-${ARCH}',
         'type=registry,ref=ghcr.io/djbender/core:jammy-dev'
-      ]
-    end
-  end
-
-  describe '#cache_to_dev' do
-    it 'returns single-element array with dev mode=max' do
-      expect(metadata.cache_to_dev).to eq [
-        'type=registry,ref=ghcr.io/djbender/core:cache-dev-jammy,mode=max'
       ]
     end
   end


### PR DESCRIPTION
## Summary
- Local builds now pull CI's `mode=max` per-arch cache tags (e.g. `cache-noble-arm64`) via `ARCH` HCL variable, instead of only using image tags as cache sources
- `ARCH` is auto-detected from `RUBY_PLATFORM` in `build.rake`, overridable via `ARCH=amd64 bin/rake build:core`
- Remove `cache-to` from bake files — CI overrides it via `--set` and local builds don't push cache
- Remove `cache_to`/`cache_to_dev` from `Metadata` (dead code, only CI uses `CacheRef.to` directly)