### PR TITLE
Pin container-retention-policy to v3.0.1, rewrite README

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         package: [core, ruby, node]
     steps:
-      - uses: snok/container-retention-policy@v3
+      - uses: snok/container-retention-policy@v3.0.1
         with:
           account: djbender
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-28
+- Pin `snok/container-retention-policy` to v3.0.1 (v3 tag doesn't exist, failing weekly since 2026-03-01)
+- Rewrite README with image version table and clearer build/dev instructions
+
 ## 2026-03-25
 - Bump Node 20 to 20.20.2, Node 22 to 22.22.2, Node 24 to 24.14.1, Node 25 to 25.8.2
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # docker-base-images
 [![Build Images](https://github.com/djbender/docker-base-images/actions/workflows/build-images.yml/badge.svg)](https://github.com/djbender/docker-base-images/actions/workflows/build-images.yml)
 
-Multi architecture docker base images
+Multi-architecture (amd64/arm64) Docker base images published to `ghcr.io/djbender`.
 
-Available images:
-- [Core - Ubuntu Bionic, Jammy, Noble](core/)
-- [Ruby](ruby/)
-- [Node](node/)
+## Available images
 
-# How to build
+| Image | Versions |
+|-------|----------|
+| [Core](core/) | `noble` (latest), `jammy`, `bionic` — includes `-dev` variants |
+| [Ruby](ruby/) | `2.4`, `2.5`, `2.6`, `2.7`, `3.0`, `3.1`, `3.2`, `3.3`, `3.4`, `4.0` (latest) |
+| [Node](node/) | `16`, `18`, `20`, `22`, `24` (latest), `25` |
+
+## Building images
 
 ```bash
 docker buildx bake -f ruby/4.0/docker-bake.hcl
 ```
 
-To build only for your native architecture (faster, loads image locally):
+To build for your native architecture only (faster, loads image locally):
 
 ```bash
 docker buildx bake -f ruby/4.0/docker-bake.hcl \
@@ -24,27 +27,37 @@ docker buildx bake -f ruby/4.0/docker-bake.hcl \
   --load
 ```
 
-## Build cache (optional)
+### Build cache (optional)
 
-Log in to ghcr.io for faster builds:
+Log in to ghcr.io for faster builds using the remote layer cache:
 
 ```bash
 echo $GHCR_PAT | docker login ghcr.io -u USERNAME --password-stdin
 ```
 
-Without this, you'll see errors like:
-```
-#9 importing cache manifest from ghcr.io/djbender/core:jammy-cache
-#9 ERROR: failed to configure registry cache importer: failed to authorize: failed to fetch anonymous token: unexpected status: 401 Unauthorized
-```
+Without this you'll see 401 errors when pulling cache manifests — builds still work, just slower.
 
 ## Development
-We use `ruby` , and `erb` templates to generate our Dockerfile's
-- Install `ruby`, ([chruby](https://github.com/postmodern/chruby), or [asdf](https://github.com/asdf-vm/asdf))
-- `bundle install`
-- `bundle exec rake -T` to see rake tasks
 
-You can install some useful git-hooks by install [overcommit](https://github.com/sds/overcommit#installation)
-- `gem install overcommit`
-- `cp .overcommit.sample.yml .overcommit.yml`
-- `overcommit --install`
+Images are defined in [`manifest.yml`](manifest.yml). Dockerfiles and bake configs are auto-generated from ERB templates — never edit them directly.
+
+```bash
+bin/rake generate:all        # regenerate all Dockerfiles from templates
+bin/rake generate:[core|ruby|node]  # regenerate specific image type
+bin/rubocop                  # lint
+bin/rspec                    # tests
+```
+
+### Setup
+
+- Install Ruby ([chruby](https://github.com/postmodern/chruby) or [asdf](https://github.com/asdf-vm/asdf))
+- `bin/bundle install`
+- `bin/rake -T` to list all tasks
+
+### Git hooks (optional)
+
+```bash
+gem install overcommit
+cp .overcommit.sample.yml .overcommit.yml
+overcommit --install
+```


### PR DESCRIPTION
## Summary
- Pin `snok/container-retention-policy` to `v3.0.1` — the `v3` tag doesn't exist, only semver tags. Weekly cleanup job has failed every run since 2026-03-01.
- Rewrite README with image version table and clearer build/dev instructions.