### PR TITLE
Fix cleanup-packages workflow for v3.0.1

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -20,7 +20,8 @@ jobs:
           account: djbender
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: ${{ matrix.package }}
-          cut-off: 1 week ago UTC
-          # Delete tags matching run_id pattern (digits only between version and arch)
-          tag-regex: '.*-\d{9,}-(?:amd64|arm64)$'
+          cut-off: 1w
+          # Delete intermediate arch-specific build tags (e.g. jammy-1234567890-amd64)
+          image-tags: "*-amd64 *-arm64"
+          tag-selection: tagged
           keep-n-most-recent: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Pin `snok/container-retention-policy` to v3.0.1 (v3 tag doesn't exist, failing weekly since 2026-03-01)
 - Rewrite README with image version table and clearer build/dev instructions
 - Bump rubocop 1.85.1 → 1.86.0
+- Fix cleanup-packages workflow: use humantime `cut-off` format and replace removed `tag-regex` with `image-tags` globs
 
 ## 2026-03-25
 - Bump Node 20 to 20.20.2, Node 22 to 22.22.2, Node 24 to 24.14.1, Node 25 to 25.8.2


### PR DESCRIPTION
## Summary
- Fix `cut-off` format: `"1 week ago UTC"` → `"1w"` (humantime format required by Rust rewrite)
- Replace removed `tag-regex` input with `image-tags` globs (`"*-amd64 *-arm64"`)
- Add explicit `tag-selection: tagged`

Workflow has been failing every week since at least 2026-02-08.