### PR TITLE
Fix cleanup-packages: use account: user, dry-run

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -15,16 +15,9 @@ jobs:
       matrix:
         package: [core, ruby, node]
     steps:
-      - name: Debug API response
-        run: |
-          curl -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/users/djbender/packages/container/${{ matrix.package }}
       - uses: snok/container-retention-policy@v3.0.1
         with:
-          account: djbender
+          account: user
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: ${{ matrix.package }}
           cut-off: 1w
@@ -32,3 +25,4 @@ jobs:
           image-tags: "*-amd64 *-arm64"
           tag-selection: tagged
           keep-n-most-recent: 0
+          dry-run: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Rewrite README with image version table and clearer build/dev instructions
 - Bump rubocop 1.85.1 → 1.86.0
 - Fix cleanup-packages workflow: use humantime `cut-off` format and replace removed `tag-regex` with `image-tags` globs
+- Fix cleanup-packages `account` from `djbender` to `user` (personal account literal required by v3), enable dry-run, remove debug curl
 
 ## 2026-03-25
 - Bump Node 20 to 20.20.2, Node 22 to 22.22.2, Node 24 to 24.14.1, Node 25 to 25.8.2


### PR DESCRIPTION
## Summary
- Fix `account` from `djbender` to literal `user` (required by v3 for personal accounts)
- Enable `dry-run: true` to verify before live deletion
- Remove debug curl step from previous PR

Investigating https://github.com/snok/container-retention-policy/issues/96