### PR TITLE
Remove dry-run from cleanup-packages workflow

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -25,4 +25,3 @@ jobs:
           image-tags: "*-amd64 *-arm64"
           tag-selection: tagged
           keep-n-most-recent: 0
-          dry-run: true


### PR DESCRIPTION
## Summary
- Remove `dry-run: true` from cleanup-packages workflow
- Dry-run confirmed correct targeting: 2,340 intermediate arch-specific build tags (`{version}-{run_id}-{arch}`) across core/ruby/node
- No final tags or cache tags affected