### PR TITLE
Switch to dataaxiom/ghcr-cleanup-action

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -11,18 +11,16 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package: [core, ruby, node]
+    concurrency:
+      group: cleanup-packages
     steps:
-      - uses: snok/container-retention-policy@v3.0.1
+      - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          account: user
-          token: ${{ secrets.GITHUB_TOKEN }}
-          image-names: ${{ matrix.package }}
-          cut-off: 1w
-          # Delete intermediate arch-specific build tags (e.g. jammy-1234567890-amd64)
-          image-tags: "*-amd64 *-arm64"
-          tag-selection: tagged
-          keep-n-most-recent: 0
+          packages: core,ruby,node
+          delete-tags: '*-amd64,*-arm64'
+          delete-untagged: true
+          older-than: 1 week
+          delete-ghost-images: true
+          delete-partial-images: true
+          delete-orphaned-images: true
           dry-run: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bump rubocop 1.85.1 → 1.86.0
 - Fix cleanup-packages workflow: use humantime `cut-off` format and replace removed `tag-regex` with `image-tags` globs
 - Fix cleanup-packages `account` from `djbender` to `user` (personal account literal required by v3), enable dry-run, remove debug curl
+- Replace `snok/container-retention-policy` with `dataaxiom/ghcr-cleanup-action` for multi-arch-aware cleanup including untagged orphans
 
 ## 2026-03-25
 - Bump Node 20 to 20.20.2, Node 22 to 22.22.2, Node 24 to 24.14.1, Node 25 to 25.8.2


### PR DESCRIPTION
## Summary
- Replace `snok/container-retention-policy` with `dataaxiom/ghcr-cleanup-action`
- Multi-arch aware: safely cleans untagged orphans without breaking live images
- Enables `delete-ghost-images`, `delete-partial-images`, `delete-orphaned-images`
- Adds concurrency group to prevent parallel runs
- `dry-run: true` for initial verification

Motivated by snok/container-retention-policy#96 — v3 broken with `GITHUB_TOKEN` on personal accounts.