### PR TITLE
Change older-than to 4 weeks, disable dry-run

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -18,8 +18,10 @@ jobs:
         with:
           packages: core,ruby,node
           delete-tags: '*-amd64,*-arm64'
+          exclude-tags: 'cache-*'
           delete-untagged: true
           older-than: 4 weeks
           delete-ghost-images: true
           delete-partial-images: true
           delete-orphaned-images: true
+          log-level: debug

--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -23,4 +23,3 @@ jobs:
           delete-ghost-images: true
           delete-partial-images: true
           delete-orphaned-images: true
-          dry-run: true

--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -19,7 +19,7 @@ jobs:
           packages: core,ruby,node
           delete-tags: '*-amd64,*-arm64'
           delete-untagged: true
-          older-than: 1 week
+          older-than: 4 weeks
           delete-ghost-images: true
           delete-partial-images: true
           delete-orphaned-images: true


### PR DESCRIPTION
## Summary
- Widen safety window from 1 week to 4 weeks
- Disable dry-run — ready for live cleanup