### PR TITLE
Parallelize cleanup-packages, exclude cache tags

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -11,12 +11,15 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [core, ruby, node]
     concurrency:
-      group: cleanup-packages
+      group: cleanup-${{ matrix.package }}
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          packages: core,ruby,node
+          package: ${{ matrix.package }}
           delete-tags: '*-amd64,*-arm64'
           exclude-tags: 'cache-*'
           delete-untagged: true
@@ -24,4 +27,3 @@ jobs:
           delete-ghost-images: true
           delete-partial-images: true
           delete-orphaned-images: true
-          log-level: debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-29
+- Parallelize cleanup-packages via matrix (one job per package) to avoid 6h+ sequential runs
+- Exclude `cache-*` tags from cleanup to preserve build cache
+
 ## 2026-03-28
 - Pin `snok/container-retention-policy` to v3.0.1 (v3 tag doesn't exist, failing weekly since 2026-03-01)
 - Rewrite README with image version table and clearer build/dev instructions


### PR DESCRIPTION
## Summary
- Split cleanup into parallel matrix jobs (core, ruby, node) to avoid 6h+ sequential runs
- Exclude `cache-*` tags from deletion to preserve build cache between runs
