### PR TITLE
Add Ubuntu 26.04 (resolute) + promote to default

### DIFF
--- a/.generated.yml
+++ b/.generated.yml
@@ -10,6 +10,7 @@ core:
 - core/bionic
 - core/jammy
 - core/noble
+- core/resolute
 ruby:
 - ruby/2.4
 - ruby/2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-04-23
+- Promote resolute (Ubuntu 26.04) to default `core:latest`; ruby 3.1+ and node 18+ rebased from noble → resolute via the globals default
+- Pin ruby 2.7 and 3.0 explicitly to noble (focal-apt openssl 1.1.1 workaround incompatible with resolute)
+
 ## 2026-04-20
 - Add GitHub link to site main nav
 - Sort image version tables descending (independent of manifest.yml order) so the latest version appears first

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Multi-architecture (amd64/arm64) Docker base images published to `ghcr.io/djbend
 
 | Image | Versions |
 |-------|----------|
-| [Core](core/) | `resolute`, `noble` (latest), `jammy`, `bionic` — includes `-dev` variants |
+| [Core](core/) | `resolute` (latest), `noble`, `jammy`, `bionic` — includes `-dev` variants |
 | [Ruby](ruby/) | `2.4`, `2.5`, `2.6`, `2.7`, `3.0`, `3.1`, `3.2`, `3.3`, `3.4`, `4.0` (latest) |
 | [Node](node/) | `16`, `18`, `20`, `22`, `24` (latest), `25` |
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Multi-architecture (amd64/arm64) Docker base images published to `ghcr.io/djbend
 
 | Image | Versions |
 |-------|----------|
-| [Core](core/) | `noble` (latest), `jammy`, `bionic` — includes `-dev` variants |
+| [Core](core/) | `resolute`, `noble` (latest), `jammy`, `bionic` — includes `-dev` variants |
 | [Ruby](ruby/) | `2.4`, `2.5`, `2.6`, `2.7`, `3.0`, `3.1`, `3.2`, `3.3`, `3.4`, `4.0` (latest) |
 | [Node](node/) | `16`, `18`, `20`, `22`, `24` (latest), `25` |
 

--- a/core/README.md
+++ b/core/README.md
@@ -8,10 +8,10 @@ development and testing and include development libraries for easy building
 of production assets.
 
 Available tags:
-- [`resolute`](ghcr.io/djbender/core:resolute)
-- [`resolute-dev`](ghcr.io/djbender/core:resolute-dev)
-- [`noble`, `latest`](ghcr.io/djbender/core:noble)
-- [`noble-dev`, `dev`](ghcr.io/djbender/core:noble-dev)
+- [`resolute`, `latest`](ghcr.io/djbender/core:resolute)
+- [`resolute-dev`, `dev`](ghcr.io/djbender/core:resolute-dev)
+- [`noble`](ghcr.io/djbender/core:noble)
+- [`noble-dev`](ghcr.io/djbender/core:noble-dev)
 - [`jammy`](ghcr.io/djbender/core:jammy)
 - [`jammy-dev`](ghcr.io/djbender/core:jammy-dev)
 - [`bionic`](ghcr.io/djbender/core:bionic)

--- a/core/README.md
+++ b/core/README.md
@@ -8,6 +8,8 @@ development and testing and include development libraries for easy building
 of production assets.
 
 Available tags:
+- [`resolute`](ghcr.io/djbender/core:resolute)
+- [`resolute-dev`](ghcr.io/djbender/core:resolute-dev)
 - [`noble`, `latest`](ghcr.io/djbender/core:noble)
 - [`noble-dev`, `dev`](ghcr.io/djbender/core:noble-dev)
 - [`jammy`](ghcr.io/djbender/core:jammy)

--- a/core/jammy/Dockerfile
+++ b/core/jammy/Dockerfile
@@ -29,8 +29,9 @@ usermod -L docker
 
 update-ca-certificates
 # See the Locals heading at https://hub.docker.com/_/ubuntu
-# Alias created as some languages (such as ruby) require the extra local
-localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+# glibc 2.42 dropped /usr/share/locale/locale.alias (Debian #1095101); upstream
+# locale-gen no longer passes -A in localedef calls either. Matches that behavior.
+localedef -i en_US -c -f UTF-8 en_US.UTF-8
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 [ $(locale -a | grep 'en_US.utf8') == 'en_US.utf8' ]
 EOT

--- a/core/noble/Dockerfile
+++ b/core/noble/Dockerfile
@@ -30,8 +30,9 @@ usermod -L docker
 
 update-ca-certificates
 # See the Locals heading at https://hub.docker.com/_/ubuntu
-# Alias created as some languages (such as ruby) require the extra local
-localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+# glibc 2.42 dropped /usr/share/locale/locale.alias (Debian #1095101); upstream
+# locale-gen no longer passes -A in localedef calls either. Matches that behavior.
+localedef -i en_US -c -f UTF-8 en_US.UTF-8
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 [ $(locale -a | grep 'en_US.utf8') == 'en_US.utf8' ]
 EOT

--- a/core/noble/docker-bake.hcl
+++ b/core/noble/docker-bake.hcl
@@ -20,10 +20,7 @@ group "default" {
 # NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
 target "core" {
   target = "core"
-  tags = [
-    "ghcr.io/djbender/core:latest",
-    "ghcr.io/djbender/core:noble"
-  ]
+  tags = ["ghcr.io/djbender/core:noble"]
   context = "${PWD}/core/noble"
   platforms = [
     "linux/amd64",
@@ -38,10 +35,7 @@ target "core" {
 target "core-dev" {
   target = "core-dev"
   inherits = ["core"]
-  tags = [
-    "ghcr.io/djbender/core:dev",
-    "ghcr.io/djbender/core:noble-dev"
-  ]
+  tags = ["ghcr.io/djbender/core:noble-dev"]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/core:cache-dev-noble-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/core:noble-dev"

--- a/core/resolute/Dockerfile
+++ b/core/resolute/Dockerfile
@@ -8,7 +8,7 @@
 # task `rake generate:core`
 
 ########## core image ##########################
-FROM ubuntu:bionic as core
+FROM ubuntu:resolute as core
 LABEL com.opencontainers.image.authors="djbender"
 LABEL org.opencontainers.image.source=https://github.com/djbender/docker-base-images
 ENV DEBIAN_FRONTEND=noninteractive
@@ -19,6 +19,7 @@ RUN <<EOT
 set -exu
 apt-get update
 apt-get install --yes --no-install-recommends \
+  adduser \
   ca-certificates \
   locales
 

--- a/core/resolute/docker-bake.hcl
+++ b/core/resolute/docker-bake.hcl
@@ -20,7 +20,10 @@ group "default" {
 # NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
 target "core" {
   target = "core"
-  tags = ["ghcr.io/djbender/core:resolute"]
+  tags = [
+    "ghcr.io/djbender/core:latest",
+    "ghcr.io/djbender/core:resolute"
+  ]
   context = "${PWD}/core/resolute"
   platforms = [
     "linux/amd64",
@@ -35,7 +38,10 @@ target "core" {
 target "core-dev" {
   target = "core-dev"
   inherits = ["core"]
-  tags = ["ghcr.io/djbender/core:resolute-dev"]
+  tags = [
+    "ghcr.io/djbender/core:dev",
+    "ghcr.io/djbender/core:resolute-dev"
+  ]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/core:cache-dev-resolute-${ARCH}",
     "type=registry,ref=ghcr.io/djbender/core:resolute-dev"

--- a/core/resolute/docker-bake.hcl
+++ b/core/resolute/docker-bake.hcl
@@ -1,0 +1,43 @@
+####################################
+# NOTICE: This is a generated file #
+####################################
+#
+# To update this file please edit the relevant template and run the generation
+# task `rake generate:core`
+
+# https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
+
+variable "PWD" {default="" }
+variable "ARCH" {default="" }
+
+group "default" {
+  targets = [
+    "core",
+    "core-dev"
+  ]
+}
+
+# NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
+target "core" {
+  target = "core"
+  tags = ["ghcr.io/djbender/core:resolute"]
+  context = "${PWD}/core/resolute"
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/core:cache-resolute-${ARCH}",
+    "type=registry,ref=ghcr.io/djbender/core:resolute"
+  ]
+}
+
+target "core-dev" {
+  target = "core-dev"
+  inherits = ["core"]
+  tags = ["ghcr.io/djbender/core:resolute-dev"]
+  cache-from = [
+    "type=registry,ref=ghcr.io/djbender/core:cache-dev-resolute-${ARCH}",
+    "type=registry,ref=ghcr.io/djbender/core:resolute-dev"
+  ]
+}

--- a/core/template/Dockerfile.erb
+++ b/core/template/Dockerfile.erb
@@ -14,7 +14,7 @@ RUN <<EOT
 set -exu
 apt-get update
 apt-get install --yes --no-install-recommends \
-<%- if distribution_code_name == 'noble' -%>
+<%- if %w[noble resolute].include?(distribution_code_name) -%>
   adduser \
 <%- end -%>
   ca-certificates \
@@ -27,8 +27,9 @@ usermod -L docker
 
 update-ca-certificates
 # See the Locals heading at https://hub.docker.com/_/ubuntu
-# Alias created as some languages (such as ruby) require the extra local
-localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+# glibc 2.42 dropped /usr/share/locale/locale.alias (Debian #1095101); upstream
+# locale-gen no longer passes -A in localedef calls either. Matches that behavior.
+localedef -i en_US -c -f UTF-8 en_US.UTF-8
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 [ $(locale -a | grep 'en_US.utf8') == 'en_US.utf8' ]
 EOT

--- a/manifest.yml
+++ b/manifest.yml
@@ -31,6 +31,9 @@ globals:
 
 core:
   versions:
+    resolute:
+      base_image: ubuntu:resolute
+      distribution_code_name: resolute
     noble:
       # NOTE: never tag non-LTS releases as latest, its better to tag the
       # specific LTS release below as latest.

--- a/manifest.yml
+++ b/manifest.yml
@@ -19,8 +19,8 @@
 globals:
   defaults:
     additional_tags: []
-    base_image: ubuntu:noble
-    distribution_code_name: noble
+    base_image: ubuntu:resolute
+    distribution_code_name: resolute
     docker_syntax: docker/dockerfile:1.4  # https://hub.docker.com/r/docker/dockerfile
     platforms:
       - linux/amd64
@@ -32,12 +32,12 @@ globals:
 core:
   versions:
     resolute:
-      base_image: ubuntu:resolute
-      distribution_code_name: resolute
-    noble:
       # NOTE: never tag non-LTS releases as latest, its better to tag the
       # specific LTS release below as latest.
       latest: true
+      base_image: ubuntu:resolute
+      distribution_code_name: resolute
+    noble:
       base_image: ubuntu:noble
       distribution_code_name: noble
     jammy:
@@ -116,12 +116,18 @@ ruby: &RUBY
       bundler_version: 2.4.22
       rubygems_version: 3.4.22
     '2.7':
+      # Ruby <=3.0 needs openssl 1.1.1 via focal apt sources (see ruby/template/Dockerfile.erb).
+      # Pin to noble (glibc 2.39) rather than inherit the resolute default.
+      base_image: "%{registry}/core:noble"
+      distribution_code_name: noble
       ruby_major: 2.7
       ruby_version: 2.7.8
       ruby_download_sha256: f22f662da504d49ce2080e446e4bea7008cee11d5ec4858fc69000d0e5b1d7fb
       bundler_version: 2.4.22
       rubygems_version: 3.4.22
     '3.0':
+      base_image: "%{registry}/core:noble"
+      distribution_code_name: noble
       ruby_major: 3.0
       ruby_version: 3.0.7
       ruby_download_sha256: 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab

--- a/node/18/docker-bake.hcl
+++ b/node/18/docker-bake.hcl
@@ -22,9 +22,9 @@ target "node" {
   target = "node"
   tags = [
     "ghcr.io/djbender/node:18",
-    "ghcr.io/djbender/node:18-noble",
+    "ghcr.io/djbender/node:18-resolute",
     "ghcr.io/djbender/node:18.20.8",
-    "ghcr.io/djbender/node:18.20.8-noble"
+    "ghcr.io/djbender/node:18.20.8-resolute"
   ]
   context = "${PWD}/node/18"
   platforms = [
@@ -42,9 +42,9 @@ target "node-dev" {
   inherits = ["node"]
   tags = [
     "ghcr.io/djbender/node:18-dev",
-    "ghcr.io/djbender/node:18-dev-noble",
+    "ghcr.io/djbender/node:18-dev-resolute",
     "ghcr.io/djbender/node:18.20.8-dev",
-    "ghcr.io/djbender/node:18.20.8-dev-noble"
+    "ghcr.io/djbender/node:18.20.8-dev-resolute"
   ]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/node:cache-dev-18-${ARCH}",

--- a/node/20/docker-bake.hcl
+++ b/node/20/docker-bake.hcl
@@ -22,9 +22,9 @@ target "node" {
   target = "node"
   tags = [
     "ghcr.io/djbender/node:20",
-    "ghcr.io/djbender/node:20-noble",
+    "ghcr.io/djbender/node:20-resolute",
     "ghcr.io/djbender/node:20.20.2",
-    "ghcr.io/djbender/node:20.20.2-noble"
+    "ghcr.io/djbender/node:20.20.2-resolute"
   ]
   context = "${PWD}/node/20"
   platforms = [
@@ -42,9 +42,9 @@ target "node-dev" {
   inherits = ["node"]
   tags = [
     "ghcr.io/djbender/node:20-dev",
-    "ghcr.io/djbender/node:20-dev-noble",
+    "ghcr.io/djbender/node:20-dev-resolute",
     "ghcr.io/djbender/node:20.20.2-dev",
-    "ghcr.io/djbender/node:20.20.2-dev-noble"
+    "ghcr.io/djbender/node:20.20.2-dev-resolute"
   ]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/node:cache-dev-20-${ARCH}",

--- a/node/22/docker-bake.hcl
+++ b/node/22/docker-bake.hcl
@@ -22,9 +22,9 @@ target "node" {
   target = "node"
   tags = [
     "ghcr.io/djbender/node:22",
-    "ghcr.io/djbender/node:22-noble",
+    "ghcr.io/djbender/node:22-resolute",
     "ghcr.io/djbender/node:22.22.2",
-    "ghcr.io/djbender/node:22.22.2-noble"
+    "ghcr.io/djbender/node:22.22.2-resolute"
   ]
   context = "${PWD}/node/22"
   platforms = [
@@ -42,9 +42,9 @@ target "node-dev" {
   inherits = ["node"]
   tags = [
     "ghcr.io/djbender/node:22-dev",
-    "ghcr.io/djbender/node:22-dev-noble",
+    "ghcr.io/djbender/node:22-dev-resolute",
     "ghcr.io/djbender/node:22.22.2-dev",
-    "ghcr.io/djbender/node:22.22.2-dev-noble"
+    "ghcr.io/djbender/node:22.22.2-dev-resolute"
   ]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/node:cache-dev-22-${ARCH}",

--- a/node/24/docker-bake.hcl
+++ b/node/24/docker-bake.hcl
@@ -22,9 +22,9 @@ target "node" {
   target = "node"
   tags = [
     "ghcr.io/djbender/node:24",
-    "ghcr.io/djbender/node:24-noble",
+    "ghcr.io/djbender/node:24-resolute",
     "ghcr.io/djbender/node:24.14.1",
-    "ghcr.io/djbender/node:24.14.1-noble",
+    "ghcr.io/djbender/node:24.14.1-resolute",
     "ghcr.io/djbender/node:latest"
   ]
   context = "${PWD}/node/24"
@@ -43,9 +43,9 @@ target "node-dev" {
   inherits = ["node"]
   tags = [
     "ghcr.io/djbender/node:24-dev",
-    "ghcr.io/djbender/node:24-dev-noble",
+    "ghcr.io/djbender/node:24-dev-resolute",
     "ghcr.io/djbender/node:24.14.1-dev",
-    "ghcr.io/djbender/node:24.14.1-dev-noble",
+    "ghcr.io/djbender/node:24.14.1-dev-resolute",
     "ghcr.io/djbender/node:dev"
   ]
   cache-from = [

--- a/node/25/docker-bake.hcl
+++ b/node/25/docker-bake.hcl
@@ -22,9 +22,9 @@ target "node" {
   target = "node"
   tags = [
     "ghcr.io/djbender/node:25",
-    "ghcr.io/djbender/node:25-noble",
+    "ghcr.io/djbender/node:25-resolute",
     "ghcr.io/djbender/node:25.9.0",
-    "ghcr.io/djbender/node:25.9.0-noble"
+    "ghcr.io/djbender/node:25.9.0-resolute"
   ]
   context = "${PWD}/node/25"
   platforms = [
@@ -42,9 +42,9 @@ target "node-dev" {
   inherits = ["node"]
   tags = [
     "ghcr.io/djbender/node:25-dev",
-    "ghcr.io/djbender/node:25-dev-noble",
+    "ghcr.io/djbender/node:25-dev-resolute",
     "ghcr.io/djbender/node:25.9.0-dev",
-    "ghcr.io/djbender/node:25.9.0-dev-noble"
+    "ghcr.io/djbender/node:25.9.0-dev-resolute"
   ]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/node:cache-dev-25-${ARCH}",

--- a/ruby/2.7/Dockerfile
+++ b/ruby/2.7/Dockerfile
@@ -8,7 +8,7 @@
 # task `rake generate:ruby`
 
 ########## Ruby image ##########################
-FROM ghcr.io/djbender/core as ruby
+FROM ghcr.io/djbender/core:noble as ruby
 LABEL org.opencontainers.image.authors="djbender"
 LABEL org.opencontainers.image.source=https://github.com/djbender/docker-base-images
 

--- a/ruby/3.0/Dockerfile
+++ b/ruby/3.0/Dockerfile
@@ -8,7 +8,7 @@
 # task `rake generate:ruby`
 
 ########## Ruby image ##########################
-FROM ghcr.io/djbender/core as ruby
+FROM ghcr.io/djbender/core:noble as ruby
 LABEL org.opencontainers.image.authors="djbender"
 LABEL org.opencontainers.image.source=https://github.com/djbender/docker-base-images
 

--- a/ruby/3.1/docker-bake.hcl
+++ b/ruby/3.1/docker-bake.hcl
@@ -22,9 +22,9 @@ target "ruby" {
   target = "ruby"
   tags = [
     "ghcr.io/djbender/ruby:3.1",
-    "ghcr.io/djbender/ruby:3.1-noble",
+    "ghcr.io/djbender/ruby:3.1-resolute",
     "ghcr.io/djbender/ruby:3.1.7",
-    "ghcr.io/djbender/ruby:3.1.7-noble"
+    "ghcr.io/djbender/ruby:3.1.7-resolute"
   ]
   context = "${PWD}/ruby/3.1"
   platforms = [
@@ -42,9 +42,9 @@ target "ruby-dev" {
   inherits = ["ruby"]
   tags = [
     "ghcr.io/djbender/ruby:3.1-dev",
-    "ghcr.io/djbender/ruby:3.1-dev-noble",
+    "ghcr.io/djbender/ruby:3.1-dev-resolute",
     "ghcr.io/djbender/ruby:3.1.7-dev",
-    "ghcr.io/djbender/ruby:3.1.7-dev-noble"
+    "ghcr.io/djbender/ruby:3.1.7-dev-resolute"
   ]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.1-${ARCH}",

--- a/ruby/3.2/docker-bake.hcl
+++ b/ruby/3.2/docker-bake.hcl
@@ -22,9 +22,9 @@ target "ruby" {
   target = "ruby"
   tags = [
     "ghcr.io/djbender/ruby:3.2",
-    "ghcr.io/djbender/ruby:3.2-noble",
+    "ghcr.io/djbender/ruby:3.2-resolute",
     "ghcr.io/djbender/ruby:3.2.11",
-    "ghcr.io/djbender/ruby:3.2.11-noble"
+    "ghcr.io/djbender/ruby:3.2.11-resolute"
   ]
   context = "${PWD}/ruby/3.2"
   platforms = [
@@ -42,9 +42,9 @@ target "ruby-dev" {
   inherits = ["ruby"]
   tags = [
     "ghcr.io/djbender/ruby:3.2-dev",
-    "ghcr.io/djbender/ruby:3.2-dev-noble",
+    "ghcr.io/djbender/ruby:3.2-dev-resolute",
     "ghcr.io/djbender/ruby:3.2.11-dev",
-    "ghcr.io/djbender/ruby:3.2.11-dev-noble"
+    "ghcr.io/djbender/ruby:3.2.11-dev-resolute"
   ]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.2-${ARCH}",

--- a/ruby/3.3/docker-bake.hcl
+++ b/ruby/3.3/docker-bake.hcl
@@ -22,9 +22,9 @@ target "ruby" {
   target = "ruby"
   tags = [
     "ghcr.io/djbender/ruby:3.3",
-    "ghcr.io/djbender/ruby:3.3-noble",
+    "ghcr.io/djbender/ruby:3.3-resolute",
     "ghcr.io/djbender/ruby:3.3.11",
-    "ghcr.io/djbender/ruby:3.3.11-noble"
+    "ghcr.io/djbender/ruby:3.3.11-resolute"
   ]
   context = "${PWD}/ruby/3.3"
   platforms = [
@@ -42,9 +42,9 @@ target "ruby-dev" {
   inherits = ["ruby"]
   tags = [
     "ghcr.io/djbender/ruby:3.3-dev",
-    "ghcr.io/djbender/ruby:3.3-dev-noble",
+    "ghcr.io/djbender/ruby:3.3-dev-resolute",
     "ghcr.io/djbender/ruby:3.3.11-dev",
-    "ghcr.io/djbender/ruby:3.3.11-dev-noble"
+    "ghcr.io/djbender/ruby:3.3.11-dev-resolute"
   ]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.3-${ARCH}",

--- a/ruby/3.4/docker-bake.hcl
+++ b/ruby/3.4/docker-bake.hcl
@@ -22,9 +22,9 @@ target "ruby" {
   target = "ruby"
   tags = [
     "ghcr.io/djbender/ruby:3.4",
-    "ghcr.io/djbender/ruby:3.4-noble",
+    "ghcr.io/djbender/ruby:3.4-resolute",
     "ghcr.io/djbender/ruby:3.4.9",
-    "ghcr.io/djbender/ruby:3.4.9-noble"
+    "ghcr.io/djbender/ruby:3.4.9-resolute"
   ]
   context = "${PWD}/ruby/3.4"
   platforms = [
@@ -42,9 +42,9 @@ target "ruby-dev" {
   inherits = ["ruby"]
   tags = [
     "ghcr.io/djbender/ruby:3.4-dev",
-    "ghcr.io/djbender/ruby:3.4-dev-noble",
+    "ghcr.io/djbender/ruby:3.4-dev-resolute",
     "ghcr.io/djbender/ruby:3.4.9-dev",
-    "ghcr.io/djbender/ruby:3.4.9-dev-noble"
+    "ghcr.io/djbender/ruby:3.4.9-dev-resolute"
   ]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.4-${ARCH}",

--- a/ruby/4.0/docker-bake.hcl
+++ b/ruby/4.0/docker-bake.hcl
@@ -22,9 +22,9 @@ target "ruby" {
   target = "ruby"
   tags = [
     "ghcr.io/djbender/ruby:4.0",
-    "ghcr.io/djbender/ruby:4.0-noble",
+    "ghcr.io/djbender/ruby:4.0-resolute",
     "ghcr.io/djbender/ruby:4.0.2",
-    "ghcr.io/djbender/ruby:4.0.2-noble",
+    "ghcr.io/djbender/ruby:4.0.2-resolute",
     "ghcr.io/djbender/ruby:latest"
   ]
   context = "${PWD}/ruby/4.0"
@@ -43,9 +43,9 @@ target "ruby-dev" {
   inherits = ["ruby"]
   tags = [
     "ghcr.io/djbender/ruby:4.0-dev",
-    "ghcr.io/djbender/ruby:4.0-dev-noble",
+    "ghcr.io/djbender/ruby:4.0-dev-resolute",
     "ghcr.io/djbender/ruby:4.0.2-dev",
-    "ghcr.io/djbender/ruby:4.0.2-dev-noble",
+    "ghcr.io/djbender/ruby:4.0.2-dev-resolute",
     "ghcr.io/djbender/ruby:dev"
   ]
   cache-from = [

--- a/site/views/architecture.erb
+++ b/site/views/architecture.erb
@@ -10,7 +10,7 @@
        └─▶ node/24/Dockerfile</code></pre>
 
 <h2>Image Hierarchy</h2>
-<pre><code>ubuntu:noble / ubuntu:jammy / ubuntu:bionic
+<pre><code>ubuntu:noble / ubuntu:resolute / ubuntu:jammy / ubuntu:bionic
   └─▶ core (base packages, users, locale)
        ├─▶ core-dev (build-essential, dev headers)
        ├─▶ ruby (Ruby + Bundler + RubyGems)

--- a/site/views/architecture.erb
+++ b/site/views/architecture.erb
@@ -4,13 +4,13 @@
 <p><code>manifest.yml</code> is the single source of truth for all image definitions.</p>
 <pre><code>manifest.yml
   └─▶ lib/image_generator.rb (ERB rendering)
-       ├─▶ core/noble/Dockerfile
-       ├─▶ core/noble/docker-bake.hcl
+       ├─▶ core/resolute/Dockerfile
+       ├─▶ core/resolute/docker-bake.hcl
        ├─▶ ruby/4.0/Dockerfile
        └─▶ node/24/Dockerfile</code></pre>
 
 <h2>Image Hierarchy</h2>
-<pre><code>ubuntu:noble / ubuntu:resolute / ubuntu:jammy / ubuntu:bionic
+<pre><code>ubuntu:resolute / ubuntu:noble / ubuntu:jammy / ubuntu:bionic
   └─▶ core (base packages, users, locale)
        ├─▶ core-dev (build-essential, dev headers)
        ├─▶ ruby (Ruby + Bundler + RubyGems)
@@ -26,7 +26,7 @@
 
 core:
   versions:
-    noble:
+    resolute:
       latest: true    # Gets the :latest tag
 
 ruby:

--- a/site/views/getting_started.erb
+++ b/site/views/getting_started.erb
@@ -1,7 +1,7 @@
 <h1>Getting Started</h1>
 
 <h2>Pulling an Image</h2>
-<pre><code><%= pull_command('core', 'noble') %></code></pre>
+<pre><code><%= pull_command('core', 'resolute') %></code></pre>
 
 <h2>Using in a Dockerfile</h2>
 <pre><code>FROM <%= registry %>/ruby:4.0
@@ -28,6 +28,6 @@ CMD ["ruby", "app.rb"]</code></pre>
 
 <h2>Dev Variants</h2>
 <p>Each image has a <code>-dev</code> variant with additional build tools:</p>
-<pre><code><%= pull_command('core', 'noble-dev') %>
+<pre><code><%= pull_command('core', 'resolute-dev') %>
 <%= pull_command('ruby', '4.0-dev') %>
 <%= pull_command('node', '24-dev') %></code></pre>


### PR DESCRIPTION
Two commits — first adds resolute, second promotes it to default. **Hold merge until 2026-04-23 (26.04 GA).**

## `1bede75` — Add Ubuntu 26.04 (resolute) core image

- Add `core/resolute/` built on `ubuntu:resolute` (26.04 LTS, GA 2026-04-23).
- Drop `-A /usr/share/locale/locale.alias` from `localedef` — glibc 2.42 (Debian #1095101) removed the file; upstream `locale-gen` stopped passing `-A` for the same reason. Regenerates noble/jammy/bionic Dockerfiles too (identical output minus the flag).
- Generalize the `adduser` conditional in `core/template/Dockerfile.erb` to cover both `noble` and `resolute` (24.04+ minimal rootfs omits `adduser`).

## `12fbadc` — Promote resolute to default base on 26.04 GA

- Flip `globals.defaults.base_image` and `distribution_code_name` from `noble` → `resolute`; move `latest: true` on `core.versions` accordingly.
- Ruby 3.1+ and Node 18+ auto-rebase onto resolute via the default.
- **Pin ruby 2.7 and 3.0 to noble explicitly** — `ruby/template/Dockerfile.erb` appends focal apt sources for openssl 1.1.1 when `ruby_major <= 3.0`; that workaround is incompatible with resolute's glibc 2.42 / openssl 3.x.
- Ruby 2.4/2.5/2.6 stay pinned to bionic; Node 16 stays pinned to jammy (unchanged).
- Docs: README, core/README, site/views/{architecture,getting_started}.erb, CHANGELOG (2026-04-23 entry).

## Distribution map after merge

| codename | ruby | node |
|----------|------|------|
| resolute (default, `:latest`) | 3.1, 3.2, 3.3, 3.4, 4.0 | 18, 20, 22, 24, 25 |
| noble | 2.7, 3.0 | — |
| jammy | — | 16 |
| bionic | 2.4, 2.5, 2.6 | — |

## Local verification (arm64)

- `core:resolute` + `core:resolute-dev` — bake succeeds, Ubuntu 26.04, docker user 9999, locale `en_US.utf-8` resolves
- `ruby:4.0` on resolute — ruby 4.0.2, bundler 2.5.14
- `node:24` on resolute — node 24.14.1, npm 11.11.0
- `ruby:2.7` still on noble — ruby 2.7.8, openssl 1.1.1f (focal workaround intact)