### PR TITLE
Sort image versions descending on site image pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2026-04-21
+- Reverse version table row order on image pages so the latest version appears first
+
 ## 2026-04-20
 - Bump Node 25 to 25.9.0 (npm 11.12.1) to match nodesource upstream
 

--- a/site/site_manifest.rb
+++ b/site/site_manifest.rb
@@ -59,11 +59,23 @@ module SiteManifest
 
     def initialize(name, versions)
       @name = name
-      @versions = versions
+      @versions = sort_versions(versions)
     end
 
     def latest_version
-      versions.find { |v| v.attrs['latest'] } || versions.last
+      versions.find { |v| v.attrs['latest'] } || versions.first
+    end
+
+    private
+
+    def sort_versions(versions)
+      versions.sort_by { |v| sort_key(v.key) }.reverse
+    end
+
+    def sort_key(key)
+      return key unless Gem::Version.correct?(key)
+
+      Gem::Version.new(key)
     end
 
     # Plain class instead of Struct to avoid overriding Struct#values

--- a/spec/site_manifest_spec.rb
+++ b/spec/site_manifest_spec.rb
@@ -80,12 +80,37 @@ RSpec.describe SiteManifest do
       ]
     end
 
+    describe '#versions' do
+      it 'sorts numeric versions in descending order regardless of input order' do
+        shuffled = [
+          SiteManifest::ImageType::Version.new('2.7', { 'version' => '2.7' }, 'ruby'),
+          SiteManifest::ImageType::Version.new('4.0', { 'version' => '4.0' }, 'ruby'),
+          SiteManifest::ImageType::Version.new('3.3', { 'version' => '3.3' }, 'ruby'),
+          SiteManifest::ImageType::Version.new('3.10', { 'version' => '3.10' }, 'ruby')
+        ]
+        type = described_class.new('ruby', shuffled)
+
+        expect(type.versions.map(&:key)).to eq(%w[4.0 3.10 3.3 2.7])
+      end
+
+      it 'sorts non-numeric versions in descending alphabetical order' do
+        shuffled = [
+          SiteManifest::ImageType::Version.new('bionic', { 'version' => 'bionic' }, 'core'),
+          SiteManifest::ImageType::Version.new('noble', { 'version' => 'noble' }, 'core'),
+          SiteManifest::ImageType::Version.new('jammy', { 'version' => 'jammy' }, 'core')
+        ]
+        type = described_class.new('core', shuffled)
+
+        expect(type.versions.map(&:key)).to eq(%w[noble jammy bionic])
+      end
+    end
+
     describe '#latest_version' do
       it 'returns the version marked latest' do
         expect(image_type.latest_version.key).to eq('4.0')
       end
 
-      it 'falls back to last version when none marked latest' do
+      it 'falls back to highest version when none marked latest' do
         no_latest = [
           SiteManifest::ImageType::Version.new('3.3', { 'version' => '3.3' }, 'ruby'),
           SiteManifest::ImageType::Version.new('3.4', { 'version' => '3.4' }, 'ruby')


### PR DESCRIPTION
## Summary
- `SiteManifest::ImageType` now sorts its versions descending, independent of `manifest.yml` key order
- Semver-shaped keys (ruby, node) sort via `Gem::Version`; non-semver keys (core) sort alphabetically descending
- `latest_version` fallback now returns the highest version instead of the last array entry