### PR TITLE
Fix CHANGELOG date and entry wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
 
-## 2026-04-21
-- Reverse version table row order on image pages so the latest version appears first
-
 ## 2026-04-20
+- Sort image version tables descending (independent of manifest.yml order) so the latest version appears first
 - Bump Node 25 to 25.9.0 (npm 11.12.1) to match nodesource upstream
 
 ## 2026-03-29


### PR DESCRIPTION
Correct 2026-04-21 → 2026-04-20 and reword the sort-versions entry to describe the actual change (sort, not reverse).