### PR TITLE
Add GitHub link to site main nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2026-04-20
+- Add GitHub link to site main nav
 - Sort image version tables descending (independent of manifest.yml order) so the latest version appears first
 - Bump Node 25 to 25.9.0 (npm 11.12.1) to match nodesource upstream
 

--- a/site/views/layout.erb
+++ b/site/views/layout.erb
@@ -21,6 +21,7 @@
         <li><a href="<%= url_for('/getting-started') %>" class="<%= active_class('/getting-started') %>">Getting Started</a></li>
         <li><a href="<%= url_for('/architecture') %>" class="<%= active_class('/architecture') %>">Architecture</a></li>
         <li><a href="<%= url_for('/changelog') %>" class="<%= active_class('/changelog') %>">Changelog</a></li>
+        <li><a href="https://github.com/djbender/docker-base-images" target="_blank" rel="noopener">GitHub</a></li>
         <li><a href="#" id="theme-toggle" role="button" class="outline contrast theme-toggle"></a></li>
       </ul>
     </nav>


### PR DESCRIPTION
## Summary
- Add GitHub repo link to the main nav in `site/views/layout.erb`, opening in a new tab