### PR TITLE
Fix node 18/20 and ruby 3.1 builds broken by resolute default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 2026-04-23
+- Pin nodesource origin via apt preferences so node 18/20 aren't shadowed by resolute's native nodejs 22.22.1
+- Pin ruby 3.1 to noble (fails to compile under resolute's gcc 15/16 due to K&R-style declarations in upstream `enc/jis/props.kwd`)
 - Promote resolute (Ubuntu 26.04) to default `core:latest`; ruby 3.1+ and node 18+ rebased from noble → resolute via the globals default
 - Pin ruby 2.7 and 3.0 explicitly to noble (focal-apt openssl 1.1.1 workaround incompatible with resolute)
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -132,6 +132,9 @@ ruby: &RUBY
       ruby_version: 3.0.7
       ruby_download_sha256: 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab
     '3.1':
+      # K&R-style declarations in enc/jis/props.kwd fail to compile under resolute's gcc 15/16. Pin to noble.
+      base_image: "%{registry}/core:noble"
+      distribution_code_name: noble
       ruby_major: 3.1
       ruby_version: 3.1.7
       ruby_download_sha256: 658acc455b6bda87ac6cc1380e86552b9c1af87055e7a127589c5bf7ed80b035

--- a/node/16/Dockerfile
+++ b/node/16/Dockerfile
@@ -29,6 +29,13 @@ RUN <<EOT
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 
+  # Force nodesource to win over Ubuntu's native nodejs package regardless of version ordering.
+  cat > /etc/apt/preferences.d/nodesource <<'PREF'
+Package: nodejs
+Pin: origin deb.nodesource.com
+Pin-Priority: 1001
+PREF
+
   apt-get update
   echo "Now checking that upstream version matches what we expect before continuing..."
   REPO_VERSION=$(apt-cache policy nodejs | grep Candidate | awk '{print $2}' | cut -d'+' -f1 | cut -d'-' -f1)

--- a/node/18/Dockerfile
+++ b/node/18/Dockerfile
@@ -29,6 +29,13 @@ RUN <<EOT
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 
+  # Force nodesource to win over Ubuntu's native nodejs package regardless of version ordering.
+  cat > /etc/apt/preferences.d/nodesource <<'PREF'
+Package: nodejs
+Pin: origin deb.nodesource.com
+Pin-Priority: 1001
+PREF
+
   apt-get update
   echo "Now checking that upstream version matches what we expect before continuing..."
   REPO_VERSION=$(apt-cache policy nodejs | grep Candidate | awk '{print $2}' | cut -d'+' -f1 | cut -d'-' -f1)

--- a/node/20/Dockerfile
+++ b/node/20/Dockerfile
@@ -29,6 +29,13 @@ RUN <<EOT
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 
+  # Force nodesource to win over Ubuntu's native nodejs package regardless of version ordering.
+  cat > /etc/apt/preferences.d/nodesource <<'PREF'
+Package: nodejs
+Pin: origin deb.nodesource.com
+Pin-Priority: 1001
+PREF
+
   apt-get update
   echo "Now checking that upstream version matches what we expect before continuing..."
   REPO_VERSION=$(apt-cache policy nodejs | grep Candidate | awk '{print $2}' | cut -d'+' -f1 | cut -d'-' -f1)

--- a/node/22/Dockerfile
+++ b/node/22/Dockerfile
@@ -29,6 +29,13 @@ RUN <<EOT
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 
+  # Force nodesource to win over Ubuntu's native nodejs package regardless of version ordering.
+  cat > /etc/apt/preferences.d/nodesource <<'PREF'
+Package: nodejs
+Pin: origin deb.nodesource.com
+Pin-Priority: 1001
+PREF
+
   apt-get update
   echo "Now checking that upstream version matches what we expect before continuing..."
   REPO_VERSION=$(apt-cache policy nodejs | grep Candidate | awk '{print $2}' | cut -d'+' -f1 | cut -d'-' -f1)

--- a/node/24/Dockerfile
+++ b/node/24/Dockerfile
@@ -29,6 +29,13 @@ RUN <<EOT
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 
+  # Force nodesource to win over Ubuntu's native nodejs package regardless of version ordering.
+  cat > /etc/apt/preferences.d/nodesource <<'PREF'
+Package: nodejs
+Pin: origin deb.nodesource.com
+Pin-Priority: 1001
+PREF
+
   apt-get update
   echo "Now checking that upstream version matches what we expect before continuing..."
   REPO_VERSION=$(apt-cache policy nodejs | grep Candidate | awk '{print $2}' | cut -d'+' -f1 | cut -d'-' -f1)

--- a/node/25/Dockerfile
+++ b/node/25/Dockerfile
@@ -29,6 +29,13 @@ RUN <<EOT
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_25.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 
+  # Force nodesource to win over Ubuntu's native nodejs package regardless of version ordering.
+  cat > /etc/apt/preferences.d/nodesource <<'PREF'
+Package: nodejs
+Pin: origin deb.nodesource.com
+Pin-Priority: 1001
+PREF
+
   apt-get update
   echo "Now checking that upstream version matches what we expect before continuing..."
   REPO_VERSION=$(apt-cache policy nodejs | grep Candidate | awk '{print $2}' | cut -d'+' -f1 | cut -d'-' -f1)

--- a/node/template/Dockerfile.erb
+++ b/node/template/Dockerfile.erb
@@ -30,6 +30,13 @@ RUN <<EOT
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_<%= node_major %>.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 
+  # Force nodesource to win over Ubuntu's native nodejs package regardless of version ordering.
+  cat > /etc/apt/preferences.d/nodesource <<'PREF'
+Package: nodejs
+Pin: origin deb.nodesource.com
+Pin-Priority: 1001
+PREF
+
   apt-get update
   echo "Now checking that upstream version matches what we expect before continuing..."
   REPO_VERSION=$(apt-cache policy nodejs | grep Candidate | awk '{print $2}' | cut -d'+' -f1 | cut -d'-' -f1)

--- a/ruby/3.1/Dockerfile
+++ b/ruby/3.1/Dockerfile
@@ -8,7 +8,7 @@
 # task `rake generate:ruby`
 
 ########## Ruby image ##########################
-FROM ghcr.io/djbender/core as ruby
+FROM ghcr.io/djbender/core:noble as ruby
 LABEL org.opencontainers.image.authors="djbender"
 LABEL org.opencontainers.image.source=https://github.com/djbender/docker-base-images
 

--- a/ruby/3.1/docker-bake.hcl
+++ b/ruby/3.1/docker-bake.hcl
@@ -22,9 +22,9 @@ target "ruby" {
   target = "ruby"
   tags = [
     "ghcr.io/djbender/ruby:3.1",
-    "ghcr.io/djbender/ruby:3.1-resolute",
+    "ghcr.io/djbender/ruby:3.1-noble",
     "ghcr.io/djbender/ruby:3.1.7",
-    "ghcr.io/djbender/ruby:3.1.7-resolute"
+    "ghcr.io/djbender/ruby:3.1.7-noble"
   ]
   context = "${PWD}/ruby/3.1"
   platforms = [
@@ -42,9 +42,9 @@ target "ruby-dev" {
   inherits = ["ruby"]
   tags = [
     "ghcr.io/djbender/ruby:3.1-dev",
-    "ghcr.io/djbender/ruby:3.1-dev-resolute",
+    "ghcr.io/djbender/ruby:3.1-dev-noble",
     "ghcr.io/djbender/ruby:3.1.7-dev",
-    "ghcr.io/djbender/ruby:3.1.7-dev-resolute"
+    "ghcr.io/djbender/ruby:3.1.7-dev-noble"
   ]
   cache-from = [
     "type=registry,ref=ghcr.io/djbender/ruby:cache-dev-3.1-${ARCH}",


### PR DESCRIPTION
## Summary
- Pin nodesource origin via `/etc/apt/preferences.d/nodesource` (Priority 1001) so `node_18.x` / `node_20.x` aren't shadowed by resolute's native `nodejs 22.22.1`.
- Pin ruby 3.1 to noble — resolute's gcc 15/16 rejects K&R-style decl in upstream `enc/jis/props.kwd` (`conflicting types for 'onig_jis_property'`). Ruby 3.2+ have the fix; 3.1 is EOL so no patch coming.

## Context
Main has been red since #317 merged (promoted resolute to default). Failing jobs: node 18 & 20 (both arches), ruby 3.1 (both arches). See run [24850064444](https://github.com/djbender/docker-base-images/actions/runs/24850064444).

Note: PR CI did **not** catch these before #317 merged because common-image builds in PR mode pull the last-pushed `core:latest` from the registry rather than the PR's freshly-built core. Tracking that detection gap separately.