### PR TITLE
Switch Gemfile source from cooldown to gem.coop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2026-04-23
+- Switch Gemfile source from `beta.gem.coop/cooldown` to `gem.coop` so Dependabot can resolve security fixes (cooldown compact_index was lagging behind published releases, hiding rack 3.2.6 and blocking 13 open rack vulnerability PRs)
 - Pin nodesource origin via apt preferences so node 18/20 aren't shadowed by resolute's native nodejs 22.22.1
 - Pin ruby 3.1 to noble (fails to compile under resolute's gcc 15/16 due to K&R-style declarations in upstream `enc/jis/props.kwd`)
 - Promote resolute (Ubuntu 26.04) to default `core:latest`; ruby 3.1+ and node 18+ rebased from noble → resolute via the globals default

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://beta.gem.coop/cooldown'
+source 'https://gem.coop'
 
 ruby file: '.ruby-version'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: https://beta.gem.coop/cooldown/
+  remote: https://gem.coop/
   specs:
     activesupport (8.1.3)
       base64


### PR DESCRIPTION
## Summary
- `beta.gem.coop/cooldown` compact_index lagging upstream releases: rack 3.2.6 shipped 2026-04-01, still not listed in `/cooldown/info/rack` 22 days later (well past the documented 48h cooldown)
- This blocks Dependabot from proposing fixes for **13 open rack security alerts** (3 high, 9 moderate, 1 low — GHSA-8vqr-qjwx-82mw and siblings, all fixed in rack 3.2.6)
- Switch to `https://gem.coop` (non-cooldown coop mirror) so Dependabot can resolve the patched version and file security PRs