### PR TITLE
Add core/resolute to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,16 @@ updates:
   # give us a way to be automatically notified when there
   # are upstream changes to roll into our own templates.
   - package-ecosystem: docker
+    directory: core/resolute
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+      - do-not-merge
+      - docker
+      - notification-only
+
+  - package-ecosystem: docker
     directory: core/noble
     schedule:
       interval: daily

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2026-04-23
+- Add `core/resolute` to `.github/dependabot.yml` so upstream Ubuntu 26.04 base-image changes are surfaced (was missed when resolute landed)
 - Switch Gemfile source from `beta.gem.coop/cooldown` to `gem.coop` so Dependabot can resolve security fixes (cooldown compact_index was lagging behind published releases, hiding rack 3.2.6 and blocking 13 open rack vulnerability PRs)
 - Pin nodesource origin via apt preferences so node 18/20 aren't shadowed by resolute's native nodejs 22.22.1
 - Pin ruby 3.1 to noble (fails to compile under resolute's gcc 15/16 due to K&R-style declarations in upstream `enc/jis/props.kwd`)


### PR DESCRIPTION
## Summary
- Adds a `package-ecosystem: docker` entry for `core/resolute` to `.github/dependabot.yml`
- Resolute (Ubuntu 26.04) was promoted to default `core:latest` in #317 but never got a matching dependabot entry, so upstream `ubuntu:resolute` changes weren't being surfaced for template review
- All other manifest.yml artifacts (node 16–25, ruby 2.4–4.0, core bionic/jammy/noble) already have entries