### PR TITLE
Bump Ruby 4.0 to 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2026-05-26
+- Bump Ruby 4.0 to 4.0.3
+
 ## 2026-05-14
 - Bump Node 24 to 24.15.0 (npm 11.12.1)
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -152,6 +152,6 @@ ruby: &RUBY
       ruby_download_sha256: 4231c54072601a171faed1699f105985e9971c94cd382b78feb4eb44eec2dd1a
     '4.0':
       ruby_major: 4.0
-      ruby_version: 4.0.2
-      ruby_download_sha256: 4618db85bb9ec04d8152d0099db488694a3d3c4f52106625e4ad547f1318db87
+      ruby_version: 4.0.3
+      ruby_download_sha256: 22cf6005d25bbe496b5ebe9224d63a1aaabfbfe02591bb5d612517c5a7836f29
       latest: true # apply the latest tag

--- a/ruby/4.0/Dockerfile
+++ b/ruby/4.0/Dockerfile
@@ -49,9 +49,9 @@ EOT
 ENV BUNDLER_VERSION 2.5.14
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.5.14
-ENV RUBY_DOWNLOAD_SHA256 4618db85bb9ec04d8152d0099db488694a3d3c4f52106625e4ad547f1318db87
+ENV RUBY_DOWNLOAD_SHA256 22cf6005d25bbe496b5ebe9224d63a1aaabfbfe02591bb5d612517c5a7836f29
 ENV RUBY_MAJOR 4.0
-ENV RUBY_VERSION 4.0.2
+ENV RUBY_VERSION 4.0.3
 
 # NOTE: some of ruby's build scripts are written in ruby so we need to install ruby
 # in order to compile ruby. We use apt-mark to uninstall packages we don't need.

--- a/ruby/4.0/docker-bake.hcl
+++ b/ruby/4.0/docker-bake.hcl
@@ -23,8 +23,8 @@ target "ruby" {
   tags = [
     "ghcr.io/djbender/ruby:4.0",
     "ghcr.io/djbender/ruby:4.0-resolute",
-    "ghcr.io/djbender/ruby:4.0.2",
-    "ghcr.io/djbender/ruby:4.0.2-resolute",
+    "ghcr.io/djbender/ruby:4.0.3",
+    "ghcr.io/djbender/ruby:4.0.3-resolute",
     "ghcr.io/djbender/ruby:latest"
   ]
   context = "${PWD}/ruby/4.0"
@@ -44,8 +44,8 @@ target "ruby-dev" {
   tags = [
     "ghcr.io/djbender/ruby:4.0-dev",
     "ghcr.io/djbender/ruby:4.0-dev-resolute",
-    "ghcr.io/djbender/ruby:4.0.2-dev",
-    "ghcr.io/djbender/ruby:4.0.2-dev-resolute",
+    "ghcr.io/djbender/ruby:4.0.3-dev",
+    "ghcr.io/djbender/ruby:4.0.3-dev-resolute",
     "ghcr.io/djbender/ruby:dev"
   ]
   cache-from = [


### PR DESCRIPTION
## Summary
- Bump Ruby 4.0.2 → 4.0.3 in manifest.yml 