### PR TITLE
Bump Ruby 4.0 to 4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2026-05-26
+- Bump Ruby 4.0 to 4.0.5
 - Bump Ruby 4.0 to 4.0.4
 - Bump Ruby 4.0 to 4.0.3
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -152,6 +152,6 @@ ruby: &RUBY
       ruby_download_sha256: 4231c54072601a171faed1699f105985e9971c94cd382b78feb4eb44eec2dd1a
     '4.0':
       ruby_major: 4.0
-      ruby_version: 4.0.4
-      ruby_download_sha256: 6ff9d2d6e75f5a6f997222ecc45f79209d663737eceb3689d1f42ab952673fb7
+      ruby_version: 4.0.5
+      ruby_download_sha256: 5dc5521ea54c726e6cc10b1b5a0f4004b27b482e61c04c99aed79315e30895e5
       latest: true # apply the latest tag

--- a/ruby/4.0/Dockerfile
+++ b/ruby/4.0/Dockerfile
@@ -49,9 +49,9 @@ EOT
 ENV BUNDLER_VERSION 2.5.14
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.5.14
-ENV RUBY_DOWNLOAD_SHA256 6ff9d2d6e75f5a6f997222ecc45f79209d663737eceb3689d1f42ab952673fb7
+ENV RUBY_DOWNLOAD_SHA256 5dc5521ea54c726e6cc10b1b5a0f4004b27b482e61c04c99aed79315e30895e5
 ENV RUBY_MAJOR 4.0
-ENV RUBY_VERSION 4.0.4
+ENV RUBY_VERSION 4.0.5
 
 # NOTE: some of ruby's build scripts are written in ruby so we need to install ruby
 # in order to compile ruby. We use apt-mark to uninstall packages we don't need.

--- a/ruby/4.0/docker-bake.hcl
+++ b/ruby/4.0/docker-bake.hcl
@@ -23,8 +23,8 @@ target "ruby" {
   tags = [
     "ghcr.io/djbender/ruby:4.0",
     "ghcr.io/djbender/ruby:4.0-resolute",
-    "ghcr.io/djbender/ruby:4.0.4",
-    "ghcr.io/djbender/ruby:4.0.4-resolute",
+    "ghcr.io/djbender/ruby:4.0.5",
+    "ghcr.io/djbender/ruby:4.0.5-resolute",
     "ghcr.io/djbender/ruby:latest"
   ]
   context = "${PWD}/ruby/4.0"
@@ -44,8 +44,8 @@ target "ruby-dev" {
   tags = [
     "ghcr.io/djbender/ruby:4.0-dev",
     "ghcr.io/djbender/ruby:4.0-dev-resolute",
-    "ghcr.io/djbender/ruby:4.0.4-dev",
-    "ghcr.io/djbender/ruby:4.0.4-dev-resolute",
+    "ghcr.io/djbender/ruby:4.0.5-dev",
+    "ghcr.io/djbender/ruby:4.0.5-dev-resolute",
     "ghcr.io/djbender/ruby:dev"
   ]
   cache-from = [


### PR DESCRIPTION
## Summary
- Bump Ruby 4.0 to 4.0.5