### PR TITLE
Update dependabot to track node/26 instead of node/25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,7 +112,7 @@ updates:
       - notification-only
 
   - package-ecosystem: docker
-    directory: node/25
+    directory: node/26
     schedule:
       interval: daily
     labels:


### PR DESCRIPTION
Node 25 was replaced by Node 26 in the manifest. Updates `.github/dependabot.yml` to match.