### PR TITLE
Generate dependabot.yml from manifest; track node/26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,9 @@
+####################################
+# NOTICE: This is a generated file #
+####################################
+#
+# To update this file please edit the relevant template and run the generation
+# task `rake generate:dependabot`
 version: 2
 
 updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,7 +112,7 @@ updates:
       - notification-only
 
   - package-ecosystem: docker
-    directory: node/25
+    directory: node/26
     schedule:
       interval: daily
     labels:

--- a/.github/template/dependabot.yml.erb
+++ b/.github/template/dependabot.yml.erb
@@ -1,0 +1,36 @@
+<%= generation_message -%>
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+      - github_actions
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+      - ruby
+
+  # These are not meant to be automatically accepted
+  # because they're templated files, however this will
+  # give us a way to be automatically notified when there
+  # are upstream changes to roll into our own templates.
+<% docker_directories.each_with_index do |dir, i| -%>
+<%= "\n" unless i.zero? -%>
+  - package-ecosystem: docker
+    directory: <%= dir %>
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+      - do-not-merge
+      - docker
+      - notification-only
+<% end -%>

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Run RuboCop
         run: bundle exec rubocop lib/ spec/ rakelib/
 
+      - name: Verify generated files are up to date
+        run: |
+          bundle exec rake generate:all
+          git diff --exit-code
+
   set-matrix:
     runs-on: ubuntu-latest
     outputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
 ## 2026-06-22
-- Generate `.github/dependabot.yml` docker entries from `manifest.yml` via new `rake generate:dependabot` task and `.github/template/dependabot.yml.erb`, so they can never drift from the image versions we build
-- Add CI step verifying generated files are up to date (`rake generate:all` + `git diff --exit-code`)
 - Bump Node 22 to 22.23.0 (npm 10.9.8)
 - Bump Node 24 to 24.17.0 (npm 11.13.0)
 - Replace Node 25 with Node 26 (26.3.1, npm 11.16.0)
+- Generate `.github/dependabot.yml` docker entries from `manifest.yml` via new `rake generate:dependabot` task and `.github/template/dependabot.yml.erb`, so they can never drift from the image versions we build
+- Add CI step verifying generated files are up to date (`rake generate:all` + `git diff --exit-code`)
+- Make `TagGenerator` read the commit SHA from an explicit `github_sha` value instead of `ENV['GITHUB_SHA']`, so template generation is deterministic regardless of environment (the SHA tag is now injected only by the CI merge matrix in `rakelib/ci.rake`, where published images are tagged)
 
 ## 2026-05-26
 - Bump Ruby 4.0 to 4.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 2026-06-22
+- Generate `.github/dependabot.yml` docker entries from `manifest.yml` via new `rake generate:dependabot` task and `.github/template/dependabot.yml.erb`, so they can never drift from the image versions we build
+- Add CI step verifying generated files are up to date (`rake generate:all` + `git diff --exit-code`)
 - Bump Node 22 to 22.23.0 (npm 10.9.8)
 - Bump Node 24 to 24.17.0 (npm 11.13.0)
 - Replace Node 25 with Node 26 (26.3.1, npm 11.16.0)

--- a/lib/dependabot_generator.rb
+++ b/lib/dependabot_generator.rb
@@ -1,0 +1,50 @@
+require 'erb'
+require_relative 'generation_message'
+require_relative 'util'
+
+# Generates .github/dependabot.yml from manifest.yml so the docker
+# ecosystem entries can never drift from the image versions we build.
+# Unlike ImageGenerator (one file per image/version), this renders a
+# single aggregate file, so it has its own lightweight generator.
+class DependabotGenerator
+  TEMPLATE_PATH = File.join('.github', 'template', 'dependabot.yml.erb').freeze
+  OUTPUT_PATH = File.join('.github', 'dependabot.yml').freeze
+
+  attr_reader :task_name
+
+  def initialize(task_name: nil)
+    @task_name = task_name
+  end
+
+  def generate
+    puts 'Generating .github/dependabot.yml'
+    File.write(output_path, render)
+    puts 'Done!'
+  end
+
+  # One docker directory (<image>/<version>) per manifest version, in
+  # manifest order. 'globals' is already removed from Util::MANIFEST.
+  def docker_directories
+    Util::MANIFEST.flat_map do |image_name, details|
+      details.fetch('versions').keys.map { |version| "#{image_name}/#{version}" }
+    end
+  end
+
+  def generation_message
+    GenerationMessage.new(task_name).render
+  end
+
+  private
+
+  def template_path
+    File.join(Util::PROJECT_DIR, TEMPLATE_PATH)
+  end
+
+  def output_path
+    File.join(Util::PROJECT_DIR, OUTPUT_PATH)
+  end
+
+  def render
+    ERB.new(File.read(template_path), trim_mode: '-').result(binding)
+  end
+end

--- a/lib/tag_generator.rb
+++ b/lib/tag_generator.rb
@@ -52,8 +52,8 @@ module TagGenerator
         tags << "#{base}:#{flavor_tag}"
       end
 
-      # SHA tag for traceability
-      tags << "#{base}:#{github_sha}" if github_sha
+      # SHA tag for traceability (CI passes github_sha; generation omits it)
+      tags << "#{base}:#{values[:github_sha]}" if values[:github_sha]
 
       # Latest/rolling tags
       tags << "#{base}:latest" if values[:latest]
@@ -68,7 +68,7 @@ module TagGenerator
     def default_dev_tags(base, values)
       tags = []
 
-      tags << "#{base}:#{github_sha}" if github_sha
+      tags << "#{base}:#{values[:github_sha]}" if values[:github_sha]
       tags << "#{base}:dev" if values[:latest]
 
       # Additional dev tags from manifest
@@ -131,10 +131,6 @@ module TagGenerator
         "#{base}:#{major}-dev-#{dist}",
         "#{base}:#{major}-dev"
       ]
-    end
-
-    def github_sha
-      ENV.fetch('GITHUB_SHA', nil)
     end
   end
 end

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -117,7 +117,8 @@ def merge_matrix(&)
           .fetch('defaults', {})
           .merge(defaults)
           .merge(version_values)
-          .merge('version' => version, 'image_name' => image_name)
+          .merge('version' => version, 'image_name' => image_name,
+                 'github_sha' => ENV.fetch('GITHUB_SHA', nil))
 
         {
           version: version,

--- a/rakelib/generate.rake
+++ b/rakelib/generate.rake
@@ -1,3 +1,4 @@
+require_relative '../lib/dependabot_generator'
 require_relative '../lib/generation_message'
 require_relative '../lib/image_generator'
 require_relative '../lib/template'
@@ -6,9 +7,14 @@ require_relative '../lib/util'
 namespace :generate do
   Util::MANIFEST.each do |image_name, details|
     desc "Generate all #{image_name} Dockerfiles"
-    task image_name do |this_task|
-      ImageGenerator.new(image_name:, details:, task_name: this_task.name).generate
+    task image_name do |t|
+      ImageGenerator.new(image_name:, details:, task_name: t.name).generate
     end
+  end
+
+  desc 'Generate .github/dependabot.yml from manifest'
+  task :dependabot do |t|
+    DependabotGenerator.new(task_name: t.name).generate
   end
 
   # This one must be last for the dependency resolution magic to work

--- a/spec/dependabot_generator_spec.rb
+++ b/spec/dependabot_generator_spec.rb
@@ -1,0 +1,54 @@
+require_relative '../lib/dependabot_generator'
+require_relative '../lib/util'
+
+RSpec.describe DependabotGenerator do
+  subject(:generator) { described_class.new(task_name: 'generate:dependabot') }
+
+  describe '#generate' do
+    before { allow(File).to receive(:write) }
+
+    it 'writes the rendered manifest to .github/dependabot.yml' do
+      generator.generate
+
+      expect(File).to have_received(:write).with(
+        a_string_ending_with('.github/dependabot.yml'),
+        a_string_including('package-ecosystem: docker')
+      )
+    end
+  end
+
+  describe '#docker_directories' do
+    it 'returns one <image>/<version> per manifest version' do
+      expected = Util::MANIFEST.flat_map do |image_name, details|
+        details.fetch('versions').keys.map { |version| "#{image_name}/#{version}" }
+      end
+
+      expect(generator.docker_directories).to eq(expected)
+    end
+
+    it 'does not include the removed globals key' do
+      expect(generator.docker_directories).not_to include(a_string_starting_with('globals/'))
+    end
+  end
+
+  describe 'rendered output' do
+    let(:output) do
+      generator.send(:render)
+    end
+
+    it 'includes the generation notice' do
+      expect(output).to include('NOTICE: This is a generated file')
+    end
+
+    it 'emits a docker stanza for every directory' do
+      generator.docker_directories.each do |dir|
+        expect(output).to include("directory: #{dir}")
+      end
+    end
+
+    it 'keeps the static github-actions and bundler ecosystems' do
+      expect(output).to include('package-ecosystem: github-actions')
+      expect(output).to include('package-ecosystem: bundler')
+    end
+  end
+end

--- a/spec/tag_generator_spec.rb
+++ b/spec/tag_generator_spec.rb
@@ -1,13 +1,8 @@
 require_relative '../lib/tag_generator'
+require_relative '../lib/util'
 
 RSpec.describe TagGenerator do
   let(:registry) { Util::REGISTRY }
-
-  around do |example|
-    original_sha = ENV.fetch('GITHUB_SHA', nil)
-    example.run
-    ENV['GITHUB_SHA'] = original_sha
-  end
 
   describe '.primary_tags' do
     context 'with core image' do
@@ -17,20 +12,27 @@ RSpec.describe TagGenerator do
         expect(tags).to include("#{registry}/core:jammy")
       end
 
-      it 'includes SHA tag when GITHUB_SHA set' do
-        ENV['GITHUB_SHA'] = 'abc123'
-
-        tags = described_class.primary_tags('core', 'version' => 'jammy')
+      it 'includes SHA tag when github_sha value present' do
+        tags = described_class.primary_tags('core', 'version' => 'jammy', 'github_sha' => 'abc123')
 
         expect(tags).to include("#{registry}/core:abc123")
       end
 
-      it 'excludes SHA tag when GITHUB_SHA not set' do
-        ENV.delete('GITHUB_SHA')
-
+      it 'excludes SHA tag when github_sha value absent' do
         tags = described_class.primary_tags('core', 'version' => 'jammy')
 
         expect(tags.none? { |t| t.match?(/:[a-f0-9]{40}$/) }).to be true
+      end
+
+      it 'does not read GITHUB_SHA from the environment' do
+        original = ENV.fetch('GITHUB_SHA', nil)
+        ENV['GITHUB_SHA'] = 'deadbeef'
+
+        tags = described_class.primary_tags('core', 'version' => 'jammy')
+
+        expect(tags).not_to include("#{registry}/core:deadbeef")
+      ensure
+        ENV['GITHUB_SHA'] = original
       end
 
       it 'includes latest tag when latest: true' do
@@ -64,8 +66,6 @@ RSpec.describe TagGenerator do
       end
 
       it 'skips version tag when flavor is dev' do
-        ENV.delete('GITHUB_SHA')
-
         tags = described_class.primary_tags('core', 'version' => 'jammy', 'flavor' => 'dev')
 
         expect(tags).not_to include("#{registry}/core:jammy")
@@ -138,8 +138,6 @@ RSpec.describe TagGenerator do
 
     context 'with unknown image' do
       it 'returns only default tags' do
-        ENV.delete('GITHUB_SHA')
-
         tags = described_class.primary_tags('unknown', 'version' => '1.0')
 
         expect(tags).to eq(["#{registry}/unknown:1.0"])
@@ -147,11 +145,10 @@ RSpec.describe TagGenerator do
     end
 
     it 'returns sorted unique tags' do
-      ENV['GITHUB_SHA'] = 'abc123'
-
       tags = described_class.primary_tags(
         'core',
         'version' => 'jammy',
+        'github_sha' => 'abc123',
         'additional_tags' => ["#{registry}/core:jammy"] # duplicate
       )
 
@@ -173,10 +170,13 @@ RSpec.describe TagGenerator do
         expect(tags).to include("#{registry}/core:jammy-dev")
       end
 
-      it 'includes SHA tag when GITHUB_SHA set' do
-        ENV['GITHUB_SHA'] = 'def456'
-
-        tags = described_class.dev_tags('core', 'version' => 'jammy', 'distribution_code_name' => 'jammy')
+      it 'includes SHA tag when github_sha value present' do
+        tags = described_class.dev_tags(
+          'core',
+          'version' => 'jammy',
+          'distribution_code_name' => 'jammy',
+          'github_sha' => 'def456'
+        )
 
         expect(tags).to include("#{registry}/core:def456")
       end
@@ -251,17 +251,13 @@ RSpec.describe TagGenerator do
 
     context 'with unknown image' do
       it 'returns only default dev tags' do
-        ENV.delete('GITHUB_SHA')
-
         tags = described_class.dev_tags('unknown', 'version' => '1.0')
 
         expect(tags).to eq([])
       end
 
-      it 'includes SHA when set' do
-        ENV['GITHUB_SHA'] = 'xyz789'
-
-        tags = described_class.dev_tags('unknown', 'version' => '1.0')
+      it 'includes SHA when github_sha value present' do
+        tags = described_class.dev_tags('unknown', 'version' => '1.0', 'github_sha' => 'xyz789')
 
         expect(tags).to eq(["#{registry}/unknown:xyz789"])
       end


### PR DESCRIPTION
## Summary
- Make `.github/dependabot.yml` docker entries a **generated** artifact derived from `manifest.yml`, eliminating manual-sync drift. Adds `.github/template/dependabot.yml.erb`, `DependabotGenerator`, and a `rake generate:dependabot` task folded into `generate:all`.
- Add a CI step (`rake generate:all` + `git diff --exit-code`) that fails the test job when any generated file (dependabot.yml, Dockerfiles, bake configs) is stale — a PR adding an image version without regenerating now goes red.
- Update dependabot to track `node/26` instead of `node/25`.

## Notes
- PR-blocking is only enforced if branch protection requires the `test` check.
- New generator is fully covered; suite at 100% line/branch.